### PR TITLE
support --gaiji-dir option with optparse

### DIFF
--- a/bin/aozora2html
+++ b/bin/aozora2html
@@ -1,6 +1,7 @@
 #!/usr/bin/env ruby
 
 require 'aozora2html'
+require 'optparse'
 
 # override Aozora2Html#push_chars
 #
@@ -26,12 +27,17 @@ class Aozora2Html
   end
 end
 
-def usage
-  $stderr.print "usage: aozora2html <text file> <html file>\n"
+opt = OptionParser.new("Usage: aozora2html [options] <text file> <html file>\n")
+opt.on('--gaiji-dir DIR', 'setting gaiji directory')
+opt.version = Aozora2Html::VERSION
+options = opt.getopts
+
+if options["gaiji-dir"]
+  $gaiji_dir = options["gaiji-dir"]
 end
 
 if ARGV.size != 2
-  usage
+  $stderr.print opt.banner
   exit 1
 end
 


### PR DESCRIPTION
https://github.com/takahashim/aozora2html/issues/5 で外字画像用ディレクトリが決め打ちになっている問題を指摘されたので、任意のディレクトリを指定できるように修正してみました。

``` shell
aozora2html --gaiji-dir images/gaiji/ sample/tamamono_mae.txt sample/tamamono_mae2.html
```

というように、`--gaiji-dir`オプションをつけて実行すると、生成されるsample.htmlに外字が入っている場合には、

``` diff
--- sample/tamamono_mae.html    2015-10-27 23:10:43.000000000 +0900
+++ sample/tamamono_mae2.html   2015-10-27 23:11:38.000000000 +0900
@@ -126,7 +126,7 @@
 <br />
 　風のない秋の日は静かに暮れて、薄い夕霧が<ruby><rb>山科</rb><rp>（</rp><rt>やましな</rt><rp>）</rp></ruby>の村々に低く迷ったかと思うと、それが又だんだんに
明るく晴れて、千枝松がゆうべ褒めたような冴えた月が、今夜もつめたい白い影を高く浮かべた。藻が<ruby><rb>門</rb><rp>（</rp><rt>かど</rt><rp>）</rp></ruby>の柿の葉は霜が降ったように白く光っていた。<br />
 「藻よ。今夜はすこし遅うなった。堪忍しや」<br />
-　千枝松は息を切って駈けて来て、垣の外から声をかけたが内にはなんの返事もなかった。彼は急いで二、三度呼びつづけると、ようように行綱の返事がきこえた。藻は<ruby><rb>小半<img src="../../../gaiji/1-85/1-85-25.png" alt="※(「日＋向」、第3水準1-85-25)" class="gaiji" /></rb><rp>（</rp><rt>こはんとき</rt><rp>）</rp></ruby>も前に家を出たというのであった。<br />
+　千枝松は息を切って駈けて来て、垣の外から声をかけたが内にはなんの返事もなかった。彼は急いで二、三度呼びつづけると、ようように行綱の返事がきこえた。藻は<ruby><rb>小半<img src="images/gaiji/1-85/1-85-25.png" alt="※(「日＋向」、第3水準1-85-25)" class="gaiji" /></rb><rp>（</rp><rt>こはんとき</rt><rp>）</rp></ruby>も前に家を出たというのであった。<br />
 「ほう、おくれた」<br />
```

といったように、指定した外字画像ディレクトリに変更されて出力されるようになります。
