### PR TITLE
support *.zip directly from aozora.gr.jp

### DIFF
--- a/aozora2html.gemspec
+++ b/aozora2html.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.add_dependency "rubyzip"
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "test-unit"

--- a/bin/aozora2html
+++ b/bin/aozora2html
@@ -40,5 +40,14 @@ if !File.exists?(ARGV[0])
   exit 1
 end
 
-Aozora2Html.new(ARGV[0],ARGV[1]).process
+if File.extname(ARGV[0]) == ".zip"
+  require "tempfile"
+  Dir.mktmpdir do |dir|
+    tmpfile = File.join(dir, "aozora.txt")
+    Aozora2Html::Zip.unzip(ARGV[0], tmpfile)
+    Aozora2Html.new(tmpfile, ARGV[1]).process
+  end
+else
+  Aozora2Html.new(ARGV[0], ARGV[1]).process
+end
 

--- a/lib/aozora2html.rb
+++ b/lib/aozora2html.rb
@@ -1,4 +1,5 @@
 require "aozora2html/version"
+require "aozora2html/zip"
 require 't2hs.rb'
 
 ## already defined in t2hs.rb

--- a/lib/aozora2html/zip.rb
+++ b/lib/aozora2html/zip.rb
@@ -1,0 +1,11 @@
+require 'zip'
+class Aozora2Html
+  class Zip
+    def self.unzip(zipfilename, textfilename)
+      ::Zip::File.open(zipfilename) do |zip_file|
+        entry = zip_file.glob('*.txt').first
+        entry.extract(textfilename)
+      end
+    end
+  end
+end


### PR DESCRIPTION
入力として、テキストファイルだけではなく、青空文庫のzipファイルを受け取れるように修正してみました。

zipの場合、中のテキストファイルを取り出して展開したものをソースとして、HTMLファイルを生成します（一時ディレクトリを作ってそこにテキストを展開してます）。これでデバッグ等が捗るはず。
