### PR TITLE
Web上にある青空文庫ファイル・zipファイルを直接サポート

### DIFF
--- a/bin/aozora2html
+++ b/bin/aozora2html
@@ -2,6 +2,7 @@
 
 require 'aozora2html'
 require 'optparse'
+require "tempfile"
 
 # override Aozora2Html#push_chars
 #
@@ -48,19 +49,33 @@ end
 
 src_file, dest_file = ARGV[0], ARGV[1]
 
-if !File.exists?(src_file)
-  $stderr.print "file not found: #{src_file}\n"
-  exit 1
-end
+Dir.mktmpdir do |dir|
+  if src_file =~ /\Ahttps?:/
+    require 'open-uri'
+    down_file = File.join(dir, File.basename(src_file))
+    begin
+      open(down_file, "wb") do |f0|
+        open(src_file){|f1| f0.write(f1.read)}
+      end
+      src_file = down_file
+    rescue
+      $stderr.print "file not found: #{src_file}\n"
+      $stderr.print "Download Error: #{$!}\n"
+      exit 1
+    end
+  else
+    if !File.exists?(src_file)
+      $stderr.print "file not found: #{src_file}\n"
+      exit 1
+    end
+  end
 
-if File.extname(src_file) == ".zip"
-  require "tempfile"
-  Dir.mktmpdir do |dir|
+  if File.extname(src_file) == ".zip"
     tmpfile = File.join(dir, "aozora.txt")
     Aozora2Html::Zip.unzip(src_file, tmpfile)
     Aozora2Html.new(tmpfile, dest_file).process
+  else
+    Aozora2Html.new(src_file, dest_file).process
   end
-else
-  Aozora2Html.new(src_file, dest_file).process
 end
 

--- a/bin/aozora2html
+++ b/bin/aozora2html
@@ -46,19 +46,21 @@ if ARGV.size != 2
   exit 1
 end
 
-if !File.exists?(ARGV[0])
-  $stderr.print "file not found: #{ARGV[0]}\n"
+src_file, dest_file = ARGV[0], ARGV[1]
+
+if !File.exists?(src_file)
+  $stderr.print "file not found: #{src_file}\n"
   exit 1
 end
 
-if File.extname(ARGV[0]) == ".zip"
+if File.extname(src_file) == ".zip"
   require "tempfile"
   Dir.mktmpdir do |dir|
     tmpfile = File.join(dir, "aozora.txt")
-    Aozora2Html::Zip.unzip(ARGV[0], tmpfile)
-    Aozora2Html.new(tmpfile, ARGV[1]).process
+    Aozora2Html::Zip.unzip(src_file, tmpfile)
+    Aozora2Html.new(tmpfile, dest_file).process
   end
 else
-  Aozora2Html.new(ARGV[0], ARGV[1]).process
+  Aozora2Html.new(src_file, dest_file).process
 end
 


### PR DESCRIPTION
入力ファイルとしてWeb上にある青空文庫形式のファイルや、zipファイルを指定して、それをダウンロード＆HTMLに変換できるようにしてみました。

下記のように、第1引数にファイル名ではなく`http://...` みたいなURLを与えた場合、そのURLのファイルと判断して、ダウンロードしてくれます。

```
$ aozora2html http://www.aozora.gr.jp/cards/001670/files/54584_ruby_57435.zip aozora.html
```

もっとも、青空文庫で公開されているファイルであれば変換済みのHTMLをダウンロードした方が早そうですが、自前で変換したい場合や作成途中のファイル用には便利そうです。
