### PR TITLE
--use-jisx0213 also suppot Accent_tag

### DIFF
--- a/bin/aozora2html
+++ b/bin/aozora2html
@@ -40,6 +40,7 @@ end
 
 if options["use-jisx0213"]
   Embed_Gaiji_tag.use_jisx0213 = true
+  Accent_tag.use_jisx0213 = true
 end
 
 if ARGV.size < 1 || ARGV.size > 2

--- a/lib/accent_tag.rb
+++ b/lib/accent_tag.rb
@@ -1,0 +1,23 @@
+class Accent_tag
+  alias_method :to_s_orig, :to_s
+
+  def self.use_jisx0213=(val)
+    @use_jisx0213 = val
+  end
+
+  def self.use_jisx0213
+    @use_jisx0213
+  end
+
+  def jisx0213_to_unicode(code)
+    Aozora2Html::JIS2UCS[code]
+  end
+
+  def to_s
+    if Accent_tag.use_jisx0213
+      jisx0213_to_unicode(@code.sub(%r|.*/|,"").to_sym)
+    else
+      to_s_orig
+    end
+  end
+end

--- a/lib/aozora2html.rb
+++ b/lib/aozora2html.rb
@@ -3,6 +3,7 @@ require "aozora2html/zip"
 require "aozora2html/jis2ucs"
 require 't2hs'
 require 'embed_gaiji_tag'
+require 'accent_tag'
 
 ## already defined in t2hs.rb
 class Aozora2Html


### PR DESCRIPTION
`--use-jisx0213`オプションでアクセント記号の対応が抜けていたので追加します。
