### PR TITLE
support --use-unicode

### DIFF
--- a/bin/aozora2html
+++ b/bin/aozora2html
@@ -26,11 +26,35 @@ class Aozora2Html
       push_char(obj)
     end
   end
+
+  def dispatch_gaiji
+    hook = @stream.peek_char(0)
+    if hook ==  "［".encode("shift_jis")
+      read_char
+      # embed?
+      command,raw = read_to_nest("］".encode("shift_jis"))
+      try_emb = kuten2png(command)
+      if try_emb != command
+        try_emb
+      elsif command.match(/U\+([0-9A-F]{4,5})/)
+        unicode_num = $1
+        ch = Embed_Gaiji_tag.new(self, nil, nil, command)
+        ch.unicode = unicode_num
+        ch
+      else
+        # Unemb
+        escape_gaiji(command)
+      end
+    else
+      "※"
+    end
+  end
 end
 
 opt = OptionParser.new("Usage: aozora2html [options] <text file> [<html file>]\n")
 opt.on('--gaiji-dir DIR', 'setting gaiji directory')
 opt.on('--use-jisx0213', 'use JIS X 0213 character')
+opt.on('--use-unicode', 'use Unicode character')
 opt.version = Aozora2Html::VERSION
 options = opt.getopts
 
@@ -41,6 +65,10 @@ end
 if options["use-jisx0213"]
   Embed_Gaiji_tag.use_jisx0213 = true
   Accent_tag.use_jisx0213 = true
+end
+
+if options["use-unicode"]
+  Embed_Gaiji_tag.use_unicode = true
 end
 
 if ARGV.size < 1 || ARGV.size > 2

--- a/lib/embed_gaiji_tag.rb
+++ b/lib/embed_gaiji_tag.rb
@@ -1,5 +1,6 @@
 class Embed_Gaiji_tag
   alias_method :to_s_orig, :to_s
+  attr_accessor :unicode
 
   def self.use_jisx0213=(val)
     @use_jisx0213 = val
@@ -9,13 +10,23 @@ class Embed_Gaiji_tag
     @use_jisx0213
   end
 
+  def self.use_unicode=(val)
+    @use_unicode = val
+  end
+
+  def self.use_unicode
+    @use_unicode
+  end
+
   def jisx0213_to_unicode(code)
     Aozora2Html::JIS2UCS[code]
   end
 
   def to_s
-    if Embed_Gaiji_tag.use_jisx0213
+    if Embed_Gaiji_tag.use_jisx0213 && @code
       jisx0213_to_unicode(@code.to_sym)
+    elsif Embed_Gaiji_tag.use_unicode && @unicode
+      '&#x'+@unicode+';'
     else
       to_s_orig
     end


### PR DESCRIPTION
オプション `--use-unicode`を追加してみました。これは`--use-jisx0213`に似たオプションで、「JIS X 0213にはないけれど、Unicodeにあるもの」用の注記( http://www.aozora.gr.jp/annotation/external_character.html )をUnicodeの実体参照を使うようにするものです。
