### PR TITLE
fix syntax of error rising

### DIFF
--- a/lib/aozora2html/header.rb
+++ b/lib/aozora2html/header.rb
@@ -96,7 +96,7 @@ class Aozora2Html
         header_info[:subtitle] = @header[2]
         header_info[:author] = @header[3]
         if process_person(@header[4], header_info) == :author
-          raise Aozora2Html::Error.new("parser encounted author twice")
+          raise Aozora2Html::Error, "parser encounted author twice"
         end
       when 6
         header_info[:original_title] = @header[1]
@@ -104,7 +104,7 @@ class Aozora2Html
         header_info[:original_subtitle] = @header[3]
         header_info[:author] = @header[4]
         if process_person(@header[5], header_info) == :author
-          raise Aozora2Html::Error.new("parser encounted author twice")
+          raise Aozora2Html::Error, "parser encounted author twice"
         end
       end
       header_info

--- a/lib/aozora2html/i18n.rb
+++ b/lib/aozora2html/i18n.rb
@@ -6,7 +6,8 @@ class Aozora2Html
       :undefined_header => "未定義な見出しです",
       :use_crlf => "改行コードを、「CR+LF」にあらためてください",
       :error_stop => "エラー(%d行目):%s. \r\n処理を停止します",
-      :invalid_font_size => "文字サイズの指定が不正です"
+      :invalid_font_size => "文字サイズの指定が不正です",
+      :unsupported_ruby  => "サポートされていない複雑なルビ付けです"
     }
 
     def self.t(msg, *args)

--- a/lib/aozora2html/tag.rb
+++ b/lib/aozora2html/tag.rb
@@ -49,7 +49,7 @@ class Aozora2Html
     end
 
     def syntax_error
-      raise Aozora2Html::Error.new(I18n.t(:tag_syntax_error))
+      raise Aozora2Html::Error, I18n.t(:tag_syntax_error)
     end
   end
 end

--- a/lib/aozora2html/tag/ruby.rb
+++ b/lib/aozora2html/tag/ruby.rb
@@ -37,7 +37,7 @@ class Aozora2Html
     if @under_ruby.is_a?(Array) and @under_ruby.length > 0
       # cell is used, but two way cell is not supported
       if @rbspan
-        raise Aozora2Html::Error.new("サポートされていない複雑なルビ付けです")
+        raise Aozora2Html::Error, I18n.t(:unsupported_ruby)
       else
         @rbspan = @under_ruby.length
       end

--- a/lib/aozora2html/utils.rb
+++ b/lib/aozora2html/utils.rb
@@ -38,7 +38,7 @@ class Aozora2Html
       elsif size.match(SIZE_LARGE)
         "h3"
       else
-        raise Aozora2Html::Error.new(I18n.t(:undefined_header))
+        raise Aozora2Html::Error, I18n.t(:undefined_header)
       end
     end
     module_function :create_midashi_tag
@@ -73,7 +73,7 @@ class Aozora2Html
           "mado-o-midashi"
         end
       else
-        raise Aozora2Html::Error.new(I18n.t(:undefined_header))
+        raise Aozora2Html::Error, I18n.t(:undefined_header)
       end
     end
     module_function :create_midashi_class

--- a/lib/t2hs.rb
+++ b/lib/t2hs.rb
@@ -230,14 +230,14 @@ class Aozora2Html
 
   def ensure_close
     if n = @indent_stack.last
-      raise Aozora2Html::Error.new("#{convert_indent_type(n)}中に本文が終了しました")
+      raise Aozora2Html::Error, "#{convert_indent_type(n)}中に本文が終了しました"
     end
   end
 
   def explicit_close(type)
     n = check_close_match(type)
     if n
-      raise Aozora2Html::Error.new("#{n}を閉じようとしましたが、#{n}中ではありません")
+      raise Aozora2Html::Error, "#{n}を閉じようとしましたが、#{n}中ではありません"
     end
     if tag = @tag_stack.pop
       push_chars(tag)
@@ -258,7 +258,7 @@ class Aozora2Html
     when :tail
       parse_tail
     else
-      Aozora2Html::Error.new("encount undefined condition")
+      raise Aozora2Html::Error, "encount undefined condition"
     end
   end
 
@@ -495,7 +495,7 @@ class Aozora2Html
   #
   def general_output
     if @style_stack.last
-      raise Aozora2Html::Error.new("#{@style_stack.last_command}中に改行されました。改行をまたぐ要素にはブロック表記を用いてください")
+      raise Aozora2Html::Error, "#{@style_stack.last_command}中に改行されました。改行をまたぐ要素にはブロック表記を用いてください"
     end
     # bufferにインデントタグだけがあったら改行しない！
     if @noprint
@@ -1006,7 +1006,7 @@ class Aozora2Html
     elsif @style_stack.last_command.match(encount)
       push_chars(@style_stack.pop[1])
     else
-      raise Aozora2Html::Error.new("#{encount}を終了しようとしましたが、#{@style_stack.last_command}中です")
+      raise Aozora2Html::Error, "#{encount}を終了しようとしましたが、#{@style_stack.last_command}中です"
     end
   end
 
@@ -1218,26 +1218,26 @@ class Aozora2Html
                     []
                   end
       if new_upper.length > 1 and new_under.length > 1
-        raise Aozora2Html::Error.new("1つの単語に3つのルビはつけられません")
+        raise Aozora2Html::Error, "1つの単語に3つのルビはつけられません"
       end
 
       targets.each{|x|
         if x.is_a?(Aozora2Html::Tag::Ruby)
           if x.target.is_a?(Array)
             # inner Aozora2Html::Tag::Ruby is already complex ... give up
-            raise Aozora2Html::Error.new("同じ箇所に2つのルビはつけられません")
+            raise Aozora2Html::Error, "同じ箇所に2つのルビはつけられません"
           else
             if x.ruby != ""
               if new_upper.is_a?(Array)
                 new_upper.push(x.ruby)
               else
-              raise Aozora2Html::Error.new("同じ箇所に2つのルビはつけられません")
+              raise Aozora2Html::Error, "同じ箇所に2つのルビはつけられません"
               end
             else
               if new_under.is_a?(Array)
               new_under.push(x.under_ruby)
               else
-                raise Aozora2Html::Error.new("同じ箇所に2つのルビはつけられません")
+                raise Aozora2Html::Error, "同じ箇所に2つのルビはつけられません"
               end
             end
             new_targets.push(x.target)
@@ -1254,12 +1254,12 @@ class Aozora2Html
             if new_under.is_a?(Array)
               new_under.concat(un)
             elsif un.to_s.length > 0
-              raise Aozora2Html::Error.new("同じ箇所に2つのルビはつけられません")
+              raise Aozora2Html::Error, "同じ箇所に2つのルビはつけられません"
             end
             if new_upper.is_a?(Array)
               new_upper.concat(up)
             elsif up.to_s.length > 0
-              raise Aozora2Html::Error.new("同じ箇所に2つのルビはつけられません")
+              raise Aozora2Html::Error, "同じ箇所に2つのルビはつけられません"
             end
           else
             new_targets.push(x)
@@ -1329,7 +1329,7 @@ class Aozora2Html
           tag.under_ruby = under
           tag
         else
-          raise Aozora2Html::Error.new("1つの単語に3つのルビはつけられません")
+          raise Aozora2Html::Error, "1つの単語に3つのルビはつけられません"
         end
       else
         rearrange_ruby_tag(targets,"",under)


### PR DESCRIPTION
`raise`の引数を`Error.new(msg)`ではなく`Error, msg`に統一します