### PR TITLE
fix bug of gaiji prefix (※) in tail block

### DIFF
--- a/lib/t2hs.rb
+++ b/lib/t2hs.rb
@@ -700,7 +700,7 @@ class Aozora2Html
   def dispatch_gaiji
     # 「※」の次が「［」でなければ外字ではない
     if @stream.peek_char(0) !=  "［"
-      "※"
+      return "※"
     end
 
     # 「［」を読み捨てる


### PR DESCRIPTION
http://www.aozora.gr.jp/cards/001670/files/54752_61358.html のparseにエラーが出たので修正します。