### PR TITLE
remove multibyte(Shift_JIS) chars in code

### DIFF
--- a/lib/aozora2html/i18n.rb
+++ b/lib/aozora2html/i18n.rb
@@ -17,6 +17,8 @@ class Aozora2Html
       :invalid_nesting => "%sを終了しようとしましたが、%s中です",
       :dont_use_double_ruby => "同じ箇所に2つのルビはつけられません",
       :dont_allow_triple_ruby => "1つの単語に3つのルビはつけられません",
+      :warn_unexpected_terminator => "警告(%d行目):予期せぬファイル終端",
+      :warn_undefined_command => "警告(%d行目):「%s」は未対応のコマンドのため無視します",
     }
 
     def self.t(msg, *args)

--- a/lib/aozora2html/utils.rb
+++ b/lib/aozora2html/utils.rb
@@ -77,6 +77,17 @@ class Aozora2Html
       end
     end
     module_function :create_midashi_class
+
+    def convert_japanese_number(command)
+      tmp = command.tr("０-９".encode("shift_jis"), "0-9")
+      tmp.tr!("一二三四五六七八九〇".encode("shift_jis"),"1234567890")
+      tmp.gsub!(/(\d)#{"十".encode("shift_jis")}(\d)/){"#{$1}#{$2}"}
+      tmp.gsub!(/(\d)#{"十".encode("shift_jis")}/){"#{$1}0"}
+      tmp.gsub!(/#{"十".encode("shift_jis")}(\d)/){"1#{$1}"}
+      tmp.gsub!(/#{"十".encode("shift_jis")}/,"10")
+      tmp
+    end
+    module_function :convert_japanese_number
   end
 end
 

--- a/lib/extensions.rb
+++ b/lib/extensions.rb
@@ -27,5 +27,9 @@ class String
       :else
     end
   end
+
+  def to_sjis
+    self.encode("shift_jis")
+  end
 end
 

--- a/lib/t2hs.rb
+++ b/lib/t2hs.rb
@@ -1,5 +1,5 @@
-# -*- coding:shift_jis -*-
-# Â‹ó•¶ŒÉŒ`®‚ÌƒeƒLƒXƒgƒtƒ@ƒCƒ‹‚ğ html ‚É®Œ`‚·‚é ruby ƒXƒNƒŠƒvƒg
+# -*- coding:utf-8 -*-
+# é’ç©ºæ–‡åº«å½¢å¼ã®ãƒ†ã‚­ã‚¹ãƒˆãƒ•ã‚¡ã‚¤ãƒ«ã‚’ html ã«æ•´å½¢ã™ã‚‹ ruby ã‚¹ã‚¯ãƒªãƒ—ãƒˆ
 require "cgi"
 require "extensions"
 require "aozora2html/error"
@@ -18,95 +18,95 @@ $gaiji_dir = "../../../gaiji/"
 
 $css_files = Array["../../aozora.css"]
 
-# •ÏŠ·Ší–{‘Ì
+# å¤‰æ›å™¨æœ¬ä½“
 class Aozora2Html
 
-  # ‘SŠpƒoƒbƒNƒXƒ‰ƒbƒVƒ…‚ªo‚¹‚È‚¢‚©‚ç’¼‘Å‚¿
+  # å…¨è§’ãƒãƒƒã‚¯ã‚¹ãƒ©ãƒƒã‚·ãƒ¥ãŒå‡ºã›ãªã„ã‹ã‚‰ç›´æ‰“ã¡
   KU = ["18e5"].pack("h*").force_encoding("shift_jis")
   NOJI = ["18f5"].pack("h*").force_encoding("shift_jis")
   DAKUTEN = ["18d8"].pack("h*").force_encoding("shift_jis")
-  GAIJI_MARK = "¦".to_sjis
-  IGETA_MARK = "”".to_sjis
-  RUBY_BEGIN_MARK = "s".to_sjis
-  RUBY_END_MARK = "t".to_sjis
-  PAREN_BEGIN_MARK = "i".to_sjis
-  PAREN_END_MARK = "j".to_sjis
-  SIZE_SMALL = "¬".to_sjis
-  SIZE_MIDDLE = "’†".to_sjis
-  SIZE_LARGE = "‘å".to_sjis
-  TEIHON_MARK = "’ê–{F".to_sjis
-  COMMAND_BEGIN = "m".to_sjis
-  COMMAND_END = "n".to_sjis
-  ACCENT_BEGIN = "k".to_sjis
-  ACCENT_END = "l".to_sjis
-  AOZORABUNKO = "Â‹ó•¶ŒÉ".to_sjis
-  #PAT_EDITOR = /[Z’ù|•Ò|•ÒW|•ÒWZ’ù|Z’ù•ÒW]$/
-  PAT_EDITOR = "(Z’ù|•Ò|•ÒW)$".to_sjis
-  PAT_HENYAKU = "•Ò–ó$".to_sjis
-  PAT_TRANSLATOR = "–ó$".to_sjis
-  RUBY_PREFIX = "b".to_sjis
-  PAT_RUBY = /#{"s.*?t".to_sjis}/
-  PAT_DIRECTION = "(‰E|¶|ã|‰º)‚É(.*)".to_sjis
-  PAT_REF = "^u.+v".to_sjis
-  CHUUKI_COMMAND = "’‹L•t‚«".to_sjis
-  TCY_COMMAND = "c’†‰¡".to_sjis
-  KEIGAKOMI_COMMAND = "ŒrˆÍ‚İ".to_sjis
-  YOKOGUMI_COMMAND = "‰¡‘g‚İ".to_sjis
-  CAPTION_COMMAND = "ƒLƒƒƒvƒVƒ‡ƒ“".to_sjis
-  WARIGAKI_COMMAND = "Š„‘".to_sjis
-  KAERITEN_COMMAND = "•Ô‚è“_".to_sjis
-  KUNTEN_OKURIGANA_COMMAND = "ŒP“_‘—‚è‰¼–¼".to_sjis
-  MIDASHI_COMMAND = "Œ©o‚µ".to_sjis
-  OMIDASHI_COMMAND = "‘åŒ©o‚µ".to_sjis
-  NAKAMIDASHI_COMMAND = "’†Œ©o‚µ".to_sjis
-  KOMIDASHI_COMMAND = "¬Œ©o‚µ".to_sjis
-  DOGYO_OMIDASHI_COMMAND = "“¯s‘åŒ©o‚µ".to_sjis
-  DOGYO_NAKAMIDASHI_COMMAND = "“¯s’†Œ©o‚µ".to_sjis
-  DOGYO_KOMIDASHI_COMMAND = "“¯s¬Œ©o‚µ".to_sjis
-  MADO_OMIDASHI_COMMAND = "‘‹‘åŒ©o‚µ".to_sjis
-  MADO_NAKAMIDASHI_COMMAND = "‘‹’†Œ©o‚µ".to_sjis
-  MADO_KOMIDASHI_COMMAND = "‘‹¬Œ©o‚µ".to_sjis
-  LEFT_MARK = "¶".to_sjis
-  UNDER_MARK = "‰º".to_sjis
-  OVER_MARK = "ã".to_sjis
-  MAIN_MARK = "–{•¶".to_sjis
-  END_MARK = "I‚í‚è".to_sjis
-  TEN_MARK = "“_".to_sjis
-  SEN_MARK = "ü".to_sjis
-  OPEN_MARK = "‚±‚±‚©‚ç".to_sjis
-  CLOSE_MARK = "‚±‚±‚Å".to_sjis
-  MADE_MARK = "‚Ü‚Å".to_sjis
-  DOGYO_MARK = "“¯s".to_sjis
-  MADO_MARK = "‘‹".to_sjis
-  JIAGE_COMMAND = "šã‚°".to_sjis
-  JISAGE_COMMAND = "š‰º‚°".to_sjis
-  PHOTO_COMMAND = "Ê^".to_sjis
-  ORIKAESHI_COMMAND = "Ü‚è•Ô‚µ‚Ä".to_sjis
-  ONELINE_COMMAND = "‚±‚Ìs".to_sjis
-  NON_0213_GAIJI = "”ñ0213ŠOš".to_sjis
-  WARICHU_COMMAND = "Š„‚è’".to_sjis
-  TENTSUKI_COMMAND = "“V•t‚«".to_sjis
-  PAT_REST_NOTES = "(¶|‰º)‚Éu(.*)v‚Ì(ƒ‹ƒr|’‹L|–T‹L)".to_sjis
-  PAT_KUTEN = /#{"u¦v[‚Í|‚Ì]".to_sjis}/
-  PAT_KUTEN_DUAL = "¦.*¦".to_sjis
-  PAT_GAIJI = "(?:”)(.*)(?:A)(.*)".to_sjis
-  PAT_KAERITEN = "^([ˆê“ñOlŒÜ˜Zµ”ª‹ã\ƒŒã’†‰ºb‰³•¸’š“V’nl]+)$".to_sjis
-  PAT_OKURIGANA = "^i(.+)j$".to_sjis
-  PAT_REMOVE_OKURIGANA = /#{"[ij]".to_sjis}/
-  PAT_CHITSUKI = /#{"(’n•t‚«|šã‚°)(I‚í‚è)*$".to_sjis}/
-  PAT_ORIKAESHI_JISAGE = "Ü‚è•Ô‚µ‚Ä(\d*)š‰º‚°".to_sjis
-  PAT_ORIKAESHI_JISAGE2 = "(\d*)š‰º‚°AÜ‚è•Ô‚µ‚Ä(\d*)š‰º‚°".to_sjis
-  PAT_JI_LEN = "([0-9]+)š".to_sjis
-  PAT_INLINE_RUBY = "u(.*)v‚Ì’‹L•t‚«".to_sjis
-  PAT_IMAGE = "(.*)i(fig.+\.png)(A‰¡([0-9]+)~c([0-9]+))*j“ü‚é".to_sjis
-  PAT_FRONTREF = "u([^uv]*(?:u.+v)*[^uv]*)v[‚É‚Í‚Ì](u.+v‚Ì)*(.+)".to_sjis
-  PAT_RUBY_DIR = "(¶|‰º)‚Éu([^v]*)v‚Ì(ƒ‹ƒr|’‹L)".to_sjis
-  PAT_CHUUKI = /#{"u(.+?)v‚Ì’‹L".to_sjis}/
-  PAT_BOUKI = /#{"u(.)v‚Ì–T‹L".to_sjis}/
-  PAT_CHARSIZE = /#{"(.*)’iŠK(..)‚È•¶š".to_sjis}/
+  GAIJI_MARK = "â€»".to_sjis
+  IGETA_MARK = "ï¼ƒ".to_sjis
+  RUBY_BEGIN_MARK = "ã€Š".to_sjis
+  RUBY_END_MARK = "ã€‹".to_sjis
+  PAREN_BEGIN_MARK = "ï¼ˆ".to_sjis
+  PAREN_END_MARK = "ï¼‰".to_sjis
+  SIZE_SMALL = "å°".to_sjis
+  SIZE_MIDDLE = "ä¸­".to_sjis
+  SIZE_LARGE = "å¤§".to_sjis
+  TEIHON_MARK = "åº•æœ¬ï¼š".to_sjis
+  COMMAND_BEGIN = "ï¼»".to_sjis
+  COMMAND_END = "ï¼½".to_sjis
+  ACCENT_BEGIN = "ã€”".to_sjis
+  ACCENT_END = "ã€•".to_sjis
+  AOZORABUNKO = "é’ç©ºæ–‡åº«".to_sjis
+  #PAT_EDITOR = /[æ ¡è¨‚|ç·¨|ç·¨é›†|ç·¨é›†æ ¡è¨‚|æ ¡è¨‚ç·¨é›†]$/
+  PAT_EDITOR = "(æ ¡è¨‚|ç·¨|ç·¨é›†)$".to_sjis
+  PAT_HENYAKU = "ç·¨è¨³$".to_sjis
+  PAT_TRANSLATOR = "è¨³$".to_sjis
+  RUBY_PREFIX = "ï½œ".to_sjis
+  PAT_RUBY = /#{"ã€Š.*?ã€‹".to_sjis}/
+  PAT_DIRECTION = "(å³|å·¦|ä¸Š|ä¸‹)ã«(.*)".to_sjis
+  PAT_REF = "^ã€Œ.+ã€".to_sjis
+  CHUUKI_COMMAND = "æ³¨è¨˜ä»˜ã".to_sjis
+  TCY_COMMAND = "ç¸¦ä¸­æ¨ª".to_sjis
+  KEIGAKOMI_COMMAND = "ç½«å›²ã¿".to_sjis
+  YOKOGUMI_COMMAND = "æ¨ªçµ„ã¿".to_sjis
+  CAPTION_COMMAND = "ã‚­ãƒ£ãƒ—ã‚·ãƒ§ãƒ³".to_sjis
+  WARIGAKI_COMMAND = "å‰²æ›¸".to_sjis
+  KAERITEN_COMMAND = "è¿”ã‚Šç‚¹".to_sjis
+  KUNTEN_OKURIGANA_COMMAND = "è¨“ç‚¹é€ã‚Šä»®å".to_sjis
+  MIDASHI_COMMAND = "è¦‹å‡ºã—".to_sjis
+  OMIDASHI_COMMAND = "å¤§è¦‹å‡ºã—".to_sjis
+  NAKAMIDASHI_COMMAND = "ä¸­è¦‹å‡ºã—".to_sjis
+  KOMIDASHI_COMMAND = "å°è¦‹å‡ºã—".to_sjis
+  DOGYO_OMIDASHI_COMMAND = "åŒè¡Œå¤§è¦‹å‡ºã—".to_sjis
+  DOGYO_NAKAMIDASHI_COMMAND = "åŒè¡Œä¸­è¦‹å‡ºã—".to_sjis
+  DOGYO_KOMIDASHI_COMMAND = "åŒè¡Œå°è¦‹å‡ºã—".to_sjis
+  MADO_OMIDASHI_COMMAND = "çª“å¤§è¦‹å‡ºã—".to_sjis
+  MADO_NAKAMIDASHI_COMMAND = "çª“ä¸­è¦‹å‡ºã—".to_sjis
+  MADO_KOMIDASHI_COMMAND = "çª“å°è¦‹å‡ºã—".to_sjis
+  LEFT_MARK = "å·¦".to_sjis
+  UNDER_MARK = "ä¸‹".to_sjis
+  OVER_MARK = "ä¸Š".to_sjis
+  MAIN_MARK = "æœ¬æ–‡".to_sjis
+  END_MARK = "çµ‚ã‚ã‚Š".to_sjis
+  TEN_MARK = "ç‚¹".to_sjis
+  SEN_MARK = "ç·š".to_sjis
+  OPEN_MARK = "ã“ã“ã‹ã‚‰".to_sjis
+  CLOSE_MARK = "ã“ã“ã§".to_sjis
+  MADE_MARK = "ã¾ã§".to_sjis
+  DOGYO_MARK = "åŒè¡Œ".to_sjis
+  MADO_MARK = "çª“".to_sjis
+  JIAGE_COMMAND = "å­—ä¸Šã’".to_sjis
+  JISAGE_COMMAND = "å­—ä¸‹ã’".to_sjis
+  PHOTO_COMMAND = "å†™çœŸ".to_sjis
+  ORIKAESHI_COMMAND = "æŠ˜ã‚Šè¿”ã—ã¦".to_sjis
+  ONELINE_COMMAND = "ã“ã®è¡Œ".to_sjis
+  NON_0213_GAIJI = "é0213å¤–å­—".to_sjis
+  WARICHU_COMMAND = "å‰²ã‚Šæ³¨".to_sjis
+  TENTSUKI_COMMAND = "å¤©ä»˜ã".to_sjis
+  PAT_REST_NOTES = "(å·¦|ä¸‹)ã«ã€Œ(.*)ã€ã®(ãƒ«ãƒ“|æ³¨è¨˜|å‚è¨˜)".to_sjis
+  PAT_KUTEN = /#{"ã€Œâ€»ã€[ã¯|ã®]".to_sjis}/
+  PAT_KUTEN_DUAL = "â€».*â€»".to_sjis
+  PAT_GAIJI = "(?:ï¼ƒ)(.*)(?:ã€)(.*)".to_sjis
+  PAT_KAERITEN = "^([ä¸€äºŒä¸‰å››äº”å…­ä¸ƒå…«ä¹åãƒ¬ä¸Šä¸­ä¸‹ç”²ä¹™ä¸™ä¸å¤©åœ°äºº]+)$".to_sjis
+  PAT_OKURIGANA = "^ï¼ˆ(.+)ï¼‰$".to_sjis
+  PAT_REMOVE_OKURIGANA = /#{"[ï¼ˆï¼‰]".to_sjis}/
+  PAT_CHITSUKI = /#{"(åœ°ä»˜ã|å­—ä¸Šã’)(çµ‚ã‚ã‚Š)*$".to_sjis}/
+  PAT_ORIKAESHI_JISAGE = "æŠ˜ã‚Šè¿”ã—ã¦(\d*)å­—ä¸‹ã’".to_sjis
+  PAT_ORIKAESHI_JISAGE2 = "(\d*)å­—ä¸‹ã’ã€æŠ˜ã‚Šè¿”ã—ã¦(\d*)å­—ä¸‹ã’".to_sjis
+  PAT_JI_LEN = "([0-9]+)å­—".to_sjis
+  PAT_INLINE_RUBY = "ã€Œ(.*)ã€ã®æ³¨è¨˜ä»˜ã".to_sjis
+  PAT_IMAGE = "(.*)ï¼ˆ(fig.+\.png)(ã€æ¨ª([0-9]+)Ã—ç¸¦([0-9]+))*ï¼‰å…¥ã‚‹".to_sjis
+  PAT_FRONTREF = "ã€Œ([^ã€Œã€]*(?:ã€Œ.+ã€)*[^ã€Œã€]*)ã€[ã«ã¯ã®](ã€Œ.+ã€ã®)*(.+)".to_sjis
+  PAT_RUBY_DIR = "(å·¦|ä¸‹)ã«ã€Œ([^ã€]*)ã€ã®(ãƒ«ãƒ“|æ³¨è¨˜)".to_sjis
+  PAT_CHUUKI = /#{"ã€Œ(.+?)ã€ã®æ³¨è¨˜".to_sjis}/
+  PAT_BOUKI = /#{"ã€Œ(.)ã€ã®å‚è¨˜".to_sjis}/
+  PAT_CHARSIZE = /#{"(.*)æ®µéš(..)ãªæ–‡å­—".to_sjis}/
 
   DYNAMIC_CONTENTS = ("<div id=\"card\">\r\n<hr />\r\n<br />\r\n" +
-                      "<a href=\"JavaScript:goLibCard();\" id=\"goAZLibCard\">œ}‘ƒJ[ƒh</a>" +
+                      "<a href=\"JavaScript:goLibCard();\" id=\"goAZLibCard\">â—å›³æ›¸ã‚«ãƒ¼ãƒ‰</a>" +
                       "<script type=\"text/javascript\" src=\"../../contents.js\"></script>\r\n" +
                       "<script type=\"text/javascript\" src=\"../../golibcard.js\"></script>\r\n" +
                       "</div>").to_sjis
@@ -124,24 +124,24 @@ class Aozora2Html
   JIS2UCS = loader.load("../yml/jis2ucs.yml")
 
   INDENT_TYPE = {
-    :jisage => "š‰º‚°".to_sjis,
-    :chitsuki => "’n•t‚«".to_sjis,
-    :midashi => "Œ©o‚µ".to_sjis,
-    :jizume => "š‹l‚ß".to_sjis,
-    :yokogumi => "‰¡‘g‚İ".to_sjis,
-    :keigakomi => "ŒrˆÍ‚İ".to_sjis,
-    :caption => "ƒLƒƒƒvƒVƒ‡ƒ“".to_sjis,
-    :futoji => "‘¾š".to_sjis,
-    :shatai => "Î‘Ì".to_sjis,
-    :dai => "‘å‚«‚È•¶š".to_sjis,
-    :sho => "¬‚³‚È•¶š".to_sjis,
+    :jisage => "å­—ä¸‹ã’".to_sjis,
+    :chitsuki => "åœ°ä»˜ã".to_sjis,
+    :midashi => "è¦‹å‡ºã—".to_sjis,
+    :jizume => "å­—è©°ã‚".to_sjis,
+    :yokogumi => "æ¨ªçµ„ã¿".to_sjis,
+    :keigakomi => "ç½«å›²ã¿".to_sjis,
+    :caption => "ã‚­ãƒ£ãƒ—ã‚·ãƒ§ãƒ³".to_sjis,
+    :futoji => "å¤ªå­—".to_sjis,
+    :shatai => "æ–œä½“".to_sjis,
+    :dai => "å¤§ããªæ–‡å­—".to_sjis,
+    :sho => "å°ã•ãªæ–‡å­—".to_sjis,
   }
 
   DAKUTEN_KATAKANA_TABLE = {
-    "2" => "ƒJ".to_sjis,
-    "3" => "ƒJ".to_sjis,
-    "4" => "ƒ‘J".to_sjis,
-    "5" => "ƒ’J".to_sjis,
+    "2" => "ãƒ¯ã‚›".to_sjis,
+    "3" => "ãƒ°ã‚›".to_sjis,
+    "4" => "ãƒ±ã‚›".to_sjis,
+    "5" => "ãƒ²ã‚›".to_sjis,
   }
 
   def initialize(input, output)
@@ -157,17 +157,17 @@ class Aozora2Html
     end
     @buffer = []
     @ruby_buf = RubyBuffer.new
-    @section = :head  ## Œ»İˆ—’†‚ÌƒZƒNƒVƒ‡ƒ“(:head,:head_end,:chuuki,:chuuki_in,:body,:tail)
-    @header = Aozora2Html::Header.new()  ## ƒwƒbƒ_s‚Ì”z—ñ
-    @style_stack = StyleStack.new  ##ƒXƒ^ƒCƒ‹‚ÌƒXƒ^ƒbƒN
-    @chuuki_table = {} ## ÅŒã‚É‚Ç‚Ì’‹L‚ğo‚·‚©‚ğ•Û‚µ‚Ä‚¨‚­
-    @images = []  ## g—p‚µ‚½ŠOš‚Ì‰æ‘œ•Û—p
-    @indent_stack = [] ## Šî–{‚ÍƒVƒ“ƒ{ƒ‹‚¾‚ªA‚Ô‚ç‚³‚°‚Ì‚Æ‚«‚Ídivƒ^ƒO‚Ì•¶š—ñ‚ª“ü‚é
+    @section = :head  ## ç¾åœ¨å‡¦ç†ä¸­ã®ã‚»ã‚¯ã‚·ãƒ§ãƒ³(:head,:head_end,:chuuki,:chuuki_in,:body,:tail)
+    @header = Aozora2Html::Header.new()  ## ãƒ˜ãƒƒãƒ€è¡Œã®é…åˆ—
+    @style_stack = StyleStack.new  ##ã‚¹ã‚¿ã‚¤ãƒ«ã®ã‚¹ã‚¿ãƒƒã‚¯
+    @chuuki_table = {} ## æœ€å¾Œã«ã©ã®æ³¨è¨˜ã‚’å‡ºã™ã‹ã‚’ä¿æŒã—ã¦ãŠã
+    @images = []  ## ä½¿ç”¨ã—ãŸå¤–å­—ã®ç”»åƒä¿æŒç”¨
+    @indent_stack = [] ## åŸºæœ¬ã¯ã‚·ãƒ³ãƒœãƒ«ã ãŒã€ã¶ã‚‰ã•ã’ã®ã¨ãã¯divã‚¿ã‚°ã®æ–‡å­—åˆ—ãŒå…¥ã‚‹
     @tag_stack = []
-    @midashi_id = 0  ## Œ©o‚µ‚ÌƒJƒEƒ“ƒ^AŒ©o‚µ‚Ìí—Ş‚É‚æ‚Á‚Ä‘•ª‚ªˆÙ‚È‚é
-    @terprip = true  ## ‰üs§Œä—p (terpri‚ÍLisp—R—ˆ?)
-    @endchar = :eof  ## ‰ğÍI—¹•¶šAAccentParser‚âTagParser‚Å‚ÍˆÙ‚È‚é
-    @noprint = nil  ## s––‚ğ“Ç‚İ‚ñ‚¾‚Æ‚«A‰½‚ào—Í‚µ‚È‚¢‚©‚Ç‚¤‚©‚Ìƒtƒ‰ƒO
+    @midashi_id = 0  ## è¦‹å‡ºã—ã®ã‚«ã‚¦ãƒ³ã‚¿ã€è¦‹å‡ºã—ã®ç¨®é¡ã«ã‚ˆã£ã¦å¢—åˆ†ãŒç•°ãªã‚‹
+    @terprip = true  ## æ”¹è¡Œåˆ¶å¾¡ç”¨ (terpriã¯Lispç”±æ¥?)
+    @endchar = :eof  ## è§£æçµ‚äº†æ–‡å­—ã€AccentParserã‚„TagParserã§ã¯ç•°ãªã‚‹
+    @noprint = nil  ## è¡Œæœ«ã‚’èª­ã¿è¾¼ã‚“ã ã¨ãã€ä½•ã‚‚å‡ºåŠ›ã—ãªã„ã‹ã©ã†ã‹ã®ãƒ•ãƒ©ã‚°
   end
 
   def line_number
@@ -175,18 +175,18 @@ class Aozora2Html
   end
 
   def block_allowed_context?
-    # inline_tag‚ªŠJ‚¢‚Ä‚¢‚È‚¢‚©ƒ`ƒFƒbƒN‚·‚ê‚Î\•ª
+    # inline_tagãŒé–‹ã„ã¦ã„ãªã„ã‹ãƒã‚§ãƒƒã‚¯ã™ã‚Œã°ååˆ†
     @style_stack.empty?
   end
 
-  # ˆê•¶š“Ç‚İ‚Ş
+  # ä¸€æ–‡å­—èª­ã¿è¾¼ã‚€
   def read_char
     @stream.read_char
   end
 
-  # w’è‚³‚ê‚½I’[•¶š(1•¶š‚ÌString‚©CRLF)‚Ü‚Å“Ç‚İ‚Ş
+  # æŒ‡å®šã•ã‚ŒãŸçµ‚ç«¯æ–‡å­—(1æ–‡å­—ã®Stringã‹CRLF)ã¾ã§èª­ã¿è¾¼ã‚€
   #
-  #  @param [String] endchar I’[•¶š
+  #  @param [String] endchar çµ‚ç«¯æ–‡å­—
   def read_to(endchar)
     buf = ""
     loop do
@@ -211,10 +211,10 @@ class Aozora2Html
     Aozora2Html::TagParser.new(@stream, endchar, @chuuki_table, @images).process
   end
 
-  # 1s“Ç‚İ‚İ
+  # 1è¡Œèª­ã¿è¾¼ã¿
   #
-  # ‡‚í‚¹‚Ä@buffer‚àƒNƒŠƒA‚·‚é
-  # @return [String] “Ç‚İ‚ñ‚¾•¶š—ñ‚ğ•Ô‚·
+  # åˆã‚ã›ã¦@bufferã‚‚ã‚¯ãƒªã‚¢ã™ã‚‹
+  # @return [String] èª­ã¿è¾¼ã‚“ã æ–‡å­—åˆ—ã‚’è¿”ã™
   #
   def read_line
     tmp = read_to("\r\n")
@@ -222,9 +222,9 @@ class Aozora2Html
     tmp
   end
 
-  # parse‚·‚é
+  # parseã™ã‚‹
   #
-  # I—¹iI’[‚Ü‚Å—ˆ‚½ê‡j‚É‚Íthrow :terminate‚Å’Eo‚·‚é
+  # çµ‚äº†æ™‚ï¼ˆçµ‚ç«¯ã¾ã§æ¥ãŸå ´åˆï¼‰ã«ã¯throw :terminateã§è„±å‡ºã™ã‚‹
   #
   def process
     begin
@@ -251,7 +251,7 @@ class Aozora2Html
 
   def char_type(char)
     begin
-      ## `String#char_type`‚à’è‹`‚³‚ê‚Ä‚¢‚é‚Ì‚É’ˆÓ
+      ## `String#char_type`ã‚‚å®šç¾©ã•ã‚Œã¦ã„ã‚‹ã®ã«æ³¨æ„
       char.char_type
     rescue
       :else
@@ -273,8 +273,8 @@ class Aozora2Html
     @out.close
   end
 
-  # ‹L–@‚ÌƒVƒ“ƒ{ƒ‹–¼‚©‚ç•¶š—ñ‚Ö•ÏŠ·‚·‚é
-  # ƒVƒ“ƒ{ƒ‹‚ªŒ©‚Â‚©‚ç‚È‚¯‚ê‚Î‚»‚Ì‚Ü‚Ü•Ô‚·
+  # è¨˜æ³•ã®ã‚·ãƒ³ãƒœãƒ«åã‹ã‚‰æ–‡å­—åˆ—ã¸å¤‰æ›ã™ã‚‹
+  # ã‚·ãƒ³ãƒœãƒ«ãŒè¦‹ã¤ã‹ã‚‰ãªã‘ã‚Œã°ãã®ã¾ã¾è¿”ã™
   def convert_indent_type(type)
     INDENT_TYPE[type] || type
   end
@@ -307,7 +307,7 @@ class Aozora2Html
     end
   end
 
-  # –{•¶‚ªI‚í‚Á‚Ä‚æ‚¢‚©ƒ`ƒFƒbƒN‚µAI‚í‚Á‚Ä‚¢‚È‚¯‚ê‚Î—áŠO‚ğ‚ ‚°‚é
+  # æœ¬æ–‡ãŒçµ‚ã‚ã£ã¦ã‚ˆã„ã‹ãƒã‚§ãƒƒã‚¯ã—ã€çµ‚ã‚ã£ã¦ã„ãªã‘ã‚Œã°ä¾‹å¤–ã‚’ã‚ã’ã‚‹
   def ensure_close
     if n = @indent_stack.last
       raise Aozora2Html::Error, I18n.t(:terminate_in_style, convert_indent_type(n))
@@ -343,7 +343,7 @@ class Aozora2Html
   end
 
   def judge_chuuki
-    # ’‹L‚ª“ü‚é‚©‚Ç‚¤‚©ƒ`ƒFƒbƒN
+    # æ³¨è¨˜ãŒå…¥ã‚‹ã‹ã©ã†ã‹ãƒã‚§ãƒƒã‚¯
     i = 0
     loop do
       case @stream.peek_char(i)
@@ -364,11 +364,11 @@ class Aozora2Html
     end
   end
 
-  # header‚Íˆês‚¸‚Â“Ç‚Ş
+  # headerã¯ä¸€è¡Œãšã¤èª­ã‚€
   def parse_header
     string = read_line
     # refine from Tomita 09/06/14
-    if string == ""  # ‹ós‚ª‚­‚ê‚ÎA‚»‚±‚Åƒwƒbƒ_[I—¹‚Æ‚İ‚È‚·
+    if string == ""  # ç©ºè¡ŒãŒãã‚Œã°ã€ãã“ã§ãƒ˜ãƒƒãƒ€ãƒ¼çµ‚äº†ã¨ã¿ãªã™
       @section = :head_end
       @out.print @header.to_html
     else
@@ -390,13 +390,13 @@ class Aozora2Html
     end
   end
 
-  # g‚¤‚×‚«‚Å‚Í‚È‚¢•¶š‚ª‚ ‚é‚©ƒ`ƒFƒbƒN‚·‚é
+  # ä½¿ã†ã¹ãã§ã¯ãªã„æ–‡å­—ãŒã‚ã‚‹ã‹ãƒã‚§ãƒƒã‚¯ã™ã‚‹
   #
-  # Œx‚ğo—Í‚·‚é‚¾‚¯‚ÅŒ‹‰Ê‚É‚Í‰e‹¿‚ğ—^‚¦‚È‚¢BŒx‚·‚é•¶š‚ÍˆÈ‰º:
+  # è­¦å‘Šã‚’å‡ºåŠ›ã™ã‚‹ã ã‘ã§çµæœã«ã¯å½±éŸ¿ã‚’ä¸ãˆãªã„ã€‚è­¦å‘Šã™ã‚‹æ–‡å­—ã¯ä»¥ä¸‹:
   #
-  # * 1ƒoƒCƒg•¶š
-  # * `”`‚Å‚Í‚È‚­`ò`
-  # * JIS(JIS X 0208)ŠOš
+  # * 1ãƒã‚¤ãƒˆæ–‡å­—
+  # * `ï¼ƒ`ã§ã¯ãªã`â™¯`
+  # * JIS(JIS X 0208)å¤–å­—
   #
   # @return [void]
   #
@@ -452,10 +452,10 @@ class Aozora2Html
     end
   end
 
-  # –{‘Ì‰ğÍ•”
+  # æœ¬ä½“è§£æéƒ¨
   #
-  # 1•¶š‚¸‚Â“Ç‚İ‚İAdispatch‚µ‚Ä@buffer,@ruby_buf‚Ö‚µ‚Ü‚¤
-  # ‰üsƒR[ƒh‚É“–‚½‚Á‚½‚ç—­‚ß‚ñ‚¾‚à‚Ì‚ğgeneral_output‚·‚é
+  # 1æ–‡å­—ãšã¤èª­ã¿è¾¼ã¿ã€dispatchã—ã¦@buffer,@ruby_bufã¸ã—ã¾ã†
+  # æ”¹è¡Œã‚³ãƒ¼ãƒ‰ã«å½“ãŸã£ãŸã‚‰æºœã‚è¾¼ã‚“ã ã‚‚ã®ã‚’general_outputã™ã‚‹
   #
   def parse_body
     char = read_char
@@ -498,11 +498,11 @@ class Aozora2Html
     end
   end
 
-  # –{•¶‚ªI—¹‚µ‚½‚©‚Ç‚¤‚©ƒ`ƒFƒbƒN‚·‚é
+  # æœ¬æ–‡ãŒçµ‚äº†ã—ãŸã‹ã©ã†ã‹ãƒã‚§ãƒƒã‚¯ã™ã‚‹
   #
   #
   def ending_check
-    # `’ê–{F`‚Åƒtƒbƒ^(:tail)‚É‘JˆÚ
+    # `åº•æœ¬ï¼š`ã§ãƒ•ãƒƒã‚¿(:tail)ã«é·ç§»
     if @stream.peek_char(0) == TEIHON_MARK[1] and @stream.peek_char(1) == TEIHON_MARK[2]
       @section = :tail
       ensure_close
@@ -553,11 +553,11 @@ class Aozora2Html
     end
   end
 
-  # so—Í‚É@buffer‚ª‹ó‚©‚Ç‚¤‚©’²‚×‚é
+  # è¡Œå‡ºåŠ›æ™‚ã«@bufferãŒç©ºã‹ã©ã†ã‹èª¿ã¹ã‚‹
   #
-  # @buffer‚Ì’†g‚É‚æ‚Á‚Äs––‚Ìo—Í‚ªˆÙ‚È‚é‚½‚ß
+  # @bufferã®ä¸­èº«ã«ã‚ˆã£ã¦è¡Œæœ«ã®å‡ºåŠ›ãŒç•°ãªã‚‹ãŸã‚
   #
-  # @return [true, false, :inline] ‹ó•¶š‚Å‚Í‚È‚¢•¶š—ñ‚ª“ü‚Á‚Ä‚¢‚ê‚ÎfalseA1s’‹L‚È‚ç:inlineA‚»‚êˆÈŠO‚µ‚©“ü‚Á‚Ä‚¢‚È‚¯‚ê‚Îtrue
+  # @return [true, false, :inline] ç©ºæ–‡å­—ã§ã¯ãªã„æ–‡å­—åˆ—ãŒå…¥ã£ã¦ã„ã‚Œã°falseã€1è¡Œæ³¨è¨˜ãªã‚‰:inlineã€ãã‚Œä»¥å¤–ã—ã‹å…¥ã£ã¦ã„ãªã‘ã‚Œã°true
   #
   def buf_is_blank?(buf)
     buf.each do |token|
@@ -570,9 +570,9 @@ class Aozora2Html
     true
   end
 
-  # s––‚Å<br />‚ğo—Í‚·‚é‚×‚«‚©‚Ç‚¤‚©‚Ì”»•Ê—p
+  # è¡Œæœ«ã§<br />ã‚’å‡ºåŠ›ã™ã‚‹ã¹ãã‹ã©ã†ã‹ã®åˆ¤åˆ¥ç”¨
   #
-  # @return [true, false] Multiline‚Ì’‹L‚µ‚©“ü‚Á‚Ä‚¢‚È‚¯‚ê‚ÎfalseAMultiline‚Å‚à‹ó•¶š‚Å‚à‚È‚¢—v‘f‚ªŠÜ‚Ü‚ê‚Ä‚¢‚ê‚Îtrue
+  # @return [true, false] Multilineã®æ³¨è¨˜ã—ã‹å…¥ã£ã¦ã„ãªã‘ã‚Œã°falseã€Multilineã§ã‚‚ç©ºæ–‡å­—ã§ã‚‚ãªã„è¦ç´ ãŒå«ã¾ã‚Œã¦ã„ã‚Œã°true
   #
   def terpri?(buf)
     flag = true
@@ -588,10 +588,10 @@ class Aozora2Html
     flag
   end
 
-  # “Ç‚İ‚ñ‚¾s‚Ìo—Í‚ğs‚¤
+  # èª­ã¿è¾¼ã‚“ã è¡Œã®å‡ºåŠ›ã‚’è¡Œã†
   #
-  # parser‚ª‰üs•¶š‚ğ“Ç‚İ‚ñ‚¾‚çŒÄ‚Î‚ê‚éB
-  # ÅI“I‚É@ruby_buf‚Æ@buffer‚Í‰Šú‰»‚·‚é
+  # parserãŒæ”¹è¡Œæ–‡å­—ã‚’èª­ã¿è¾¼ã‚“ã ã‚‰å‘¼ã°ã‚Œã‚‹ã€‚
+  # æœ€çµ‚çš„ã«@ruby_bufã¨@bufferã¯åˆæœŸåŒ–ã™ã‚‹
   #
   # @return [void]
   #
@@ -599,7 +599,7 @@ class Aozora2Html
     if @style_stack.last
       raise Aozora2Html::Error, I18n.t(:dont_crlf_in_style, @style_stack.last_command)
     end
-    # buffer‚ÉƒCƒ“ƒfƒ“ƒgƒ^ƒO‚¾‚¯‚ª‚ ‚Á‚½‚ç‰üs‚µ‚È‚¢I
+    # bufferã«ã‚¤ãƒ³ãƒ‡ãƒ³ãƒˆã‚¿ã‚°ã ã‘ãŒã‚ã£ãŸã‚‰æ”¹è¡Œã—ãªã„ï¼
     if @noprint
       @noprint = false
       return
@@ -622,15 +622,15 @@ class Aozora2Html
       if s.is_a?(Aozora2Html::Tag::OnelineIndent)
         tail.unshift(s.close_tag)
       elsif s.is_a?(Aozora2Html::Tag::UnEmbedGaiji) and !s.escaped?
-        # Á‚µ‚Ä‚ ‚Á‚½¦‚ğ•œŠˆ‚³‚¹‚Ä
+        # æ¶ˆã—ã¦ã‚ã£ãŸâ€»ã‚’å¾©æ´»ã•ã›ã¦
         @out.print GAIJI_MARK
       end
       @out.print s.to_s
     end
 
-    # ÅŒã‚ÍCRLF‚ğo—Í‚·‚é
+    # æœ€å¾Œã¯CRLFã‚’å‡ºåŠ›ã™ã‚‹
     if @indent_stack.last.is_a?(String)
-      # ‚Ô‚ç‰º‚°indent
+      # ã¶ã‚‰ä¸‹ã’indent
       # tail always active
       @out.print tail.map{|s| s.to_s}.join("")
       if indent_type == :inline
@@ -648,9 +648,9 @@ class Aozora2Html
     end
   end
 
-  # ‘O•ûQÆ‚Ì”­Œ© Ruby,styled‚Ë‚ª‚¯“™X‚Ì‚½‚ßA—v‘f‚Ì”z—ñ‚Å•Ô‚·
+  # å‰æ–¹å‚ç…§ã®ç™ºè¦‹ Ruby,styleé‡ã­ãŒã‘ç­‰ã€…ã®ãŸã‚ã€è¦ç´ ã®é…åˆ—ã§è¿”ã™
   #
-  # ‘O•ûQÆ‚Í`››m”u››v‚É–T“_n`A`’m”u’v‚Éuƒ}ƒ}v‚Ì’‹Ln`‚Æ‚¢‚Á‚½•\‹L
+  # å‰æ–¹å‚ç…§ã¯`â—‹â—‹ï¼»ï¼ƒã€Œâ—‹â—‹ã€ã«å‚ç‚¹ï¼½`ã€`å¹å–‹ï¼»ï¼ƒã€Œå–‹ã€ã«ã€Œãƒãƒã€ã®æ³¨è¨˜ï¼½`ã¨ã„ã£ãŸè¡¨è¨˜
   def search_front_reference(string)
     if string.length == 0
       return false
@@ -666,7 +666,7 @@ class Aozora2Html
         searching_buf.pop
         search_front_reference(string)
       elsif last_string.match(Regexp.new(Regexp.quote(string)+"$"))
-        # Š®‘Sˆê’v
+        # å®Œå…¨ä¸€è‡´
         # start = match.begin(0)
         # tail = match.end(0)
         # last_string[start,tail-start] = ""
@@ -674,7 +674,7 @@ class Aozora2Html
         searching_buf.push(last_string.sub(Regexp.new(Regexp.quote(string)+"$"),""))
         [string]
       elsif string.match(Regexp.new(Regexp.quote(last_string)+"$"))
-        # •”•ªˆê’v
+        # éƒ¨åˆ†ä¸€è‡´
         tmp = searching_buf.pop
         found = search_front_reference(string.sub(Regexp.new(Regexp.quote(last_string)+"$"),""))
         if found
@@ -687,11 +687,11 @@ class Aozora2Html
     elsif last_string.is_a?(Aozora2Html::Tag::ReferenceMentioned)
       inner = last_string.target_string
       if inner == string
-        # Š®‘Sˆê’v
+        # å®Œå…¨ä¸€è‡´
         searching_buf.pop
         [last_string]
       elsif string.match(Regexp.new(Regexp.quote(inner)+"$"))
-        # •”•ªˆê’v
+        # éƒ¨åˆ†ä¸€è‡´
         tmp = searching_buf.pop
         found = search_front_reference(string.sub(Regexp.new(Regexp.quote(inner)+"$"),""))
         if found
@@ -706,10 +706,10 @@ class Aozora2Html
     end
   end
 
-  # ”­Œ©‚µ‚½‘O•ûQÆ‚ğŒ³‚É–ß‚·
+  # ç™ºè¦‹ã—ãŸå‰æ–¹å‚ç…§ã‚’å…ƒã«æˆ»ã™
   #
-  # @ruby_buf‚ª‚ ‚ê‚Î@ruby_buf‚ÉA‚È‚¯‚ê‚Î@buffer‚Épush‚·‚é
-  # ƒoƒbƒtƒ@‚ÌÅŒã‚ÆŠe—v‘f‚ª•¶š—ñ‚È‚çconcat‚µA‚Ç‚¿‚ç‚ª•¶š—ñ‚Å‚È‚¯‚ê‚Îiconcat‚Å‚«‚È‚¢‚Ì‚Åjpush‚·‚é
+  # @ruby_bufãŒã‚ã‚Œã°@ruby_bufã«ã€ãªã‘ã‚Œã°@bufferã«pushã™ã‚‹
+  # ãƒãƒƒãƒ•ã‚¡ã®æœ€å¾Œã¨å„è¦ç´ ãŒæ–‡å­—åˆ—ãªã‚‰concatã—ã€ã©ã¡ã‚‰ãŒæ–‡å­—åˆ—ã§ãªã‘ã‚Œã°ï¼ˆconcatã§ããªã„ã®ã§ï¼‰pushã™ã‚‹
   #
   # @return [void]
   #
@@ -760,12 +760,12 @@ class Aozora2Html
   end
 
   def dispatch_gaiji
-    # u¦v‚ÌŸ‚ªumv‚Å‚È‚¯‚ê‚ÎŠOš‚Å‚Í‚È‚¢
+    # ã€Œâ€»ã€ã®æ¬¡ãŒã€Œï¼»ã€ã§ãªã‘ã‚Œã°å¤–å­—ã§ã¯ãªã„
     if @stream.peek_char(0) !=  COMMAND_BEGIN
       return GAIJI_MARK
     end
 
-    # umv‚ğ“Ç‚İÌ‚Ä‚é
+    # ã€Œï¼»ã€ã‚’èª­ã¿æ¨ã¦ã‚‹
     _ = read_char
     # embed?
     command, _raw = read_to_nest(COMMAND_END)
@@ -781,17 +781,17 @@ class Aozora2Html
     end
   end
 
-  # ’‹L‹L–@‚Ìê‡•ª‚¯
+  # æ³¨è¨˜è¨˜æ³•ã®å ´åˆåˆ†ã‘
   def dispatch_aozora_command
-    # umv‚ÌŸ‚ªu”v‚Å‚È‚¯‚ê‚Î’‹L‚Å‚Í‚È‚¢
+    # ã€Œï¼»ã€ã®æ¬¡ãŒã€Œï¼ƒã€ã§ãªã‘ã‚Œã°æ³¨è¨˜ã§ã¯ãªã„
     if @stream.peek_char(0) != IGETA_MARK
       return COMMAND_BEGIN
     end
 
-    # u”v‚ğ“Ç‚İÌ‚Ä‚é
+    # ã€Œï¼ƒã€ã‚’èª­ã¿æ¨ã¦ã‚‹
     _ = read_char
     command,raw = read_to_nest(COMMAND_END)
-    # “K—p‡˜‚Í‚±‚ê‚Å‘åä•v‚©H@Œë”š•|‚¢‚æŒë”š
+    # é©ç”¨é †åºã¯ã“ã‚Œã§å¤§ä¸ˆå¤«ã‹ï¼Ÿã€€èª¤çˆ†æ€–ã„ã‚ˆèª¤çˆ†
     if command.match(ORIKAESHI_COMMAND)
       apply_burasage(command)
 
@@ -857,16 +857,16 @@ class Aozora2Html
 
   def apply_jisage(command)
     if command.match(MADE_MARK) or command.match(END_MARK)
-      # š‰º‚°I‚í‚è
+      # å­—ä¸‹ã’çµ‚ã‚ã‚Š
       explicit_close(:jisage)
       @indent_stack.pop
       nil
     elsif command.match(ONELINE_COMMAND)
-      # 1s‚¾‚¯
+      # 1è¡Œã ã‘
       @buffer.unshift(Aozora2Html::Tag::OnelineJisage.new(self, jisage_width(command)))
       nil
     elsif @buffer.length == 0 and @stream.peek_char(0) == "\r\n"
-      # command‚Ì‚İ
+      # commandã®ã¿
       @terprip = false
       implicit_close(:jisage)
       # adhook hack
@@ -913,12 +913,12 @@ class Aozora2Html
     else
       len = chitsuki_length(string)
       if multiline
-        # •¡”sw’è
+        # è¤‡æ•°è¡ŒæŒ‡å®š
         implicit_close(:chitsuki)
         @indent_stack.push(:chitsuki)
         Aozora2Html::Tag::MultilineChitsuki.new(self, len)
       else
-        # 1s‚Ì‚İ
+        # 1è¡Œã®ã¿
         Aozora2Html::Tag::OnelineChitsuki.new(self, len)
       end
     end
@@ -983,7 +983,7 @@ class Aozora2Html
   end
 
   def detect_style_size(style)
-    if style.match("¬")
+    if style.match("å°")
       :sho
     else
       :dai
@@ -1095,7 +1095,7 @@ class Aozora2Html
       # special inline ruby
       @style_stack.pop
       _whole, ruby = encount.match(PAT_INLINE_RUBY).to_a
-      push_char("</rb><rp>i</rp><rt>#{ruby}</rt><rp>j</rp></ruby>")
+      push_char("</rb><rp>ï¼ˆ</rp><rt>#{ruby}</rt><rp>ï¼‰</rp></ruby>")
     elsif @style_stack.last_command.match(encount)
       push_chars(@style_stack.pop[1])
     else
@@ -1181,7 +1181,7 @@ class Aozora2Html
     end
   end
 
-  # ƒRƒ}ƒ“ƒh•¶š—ñ‚©‚çƒ‚[ƒh‚ÌƒVƒ“ƒ{ƒ‹‚ğæ‚èo‚·
+  # ã‚³ãƒãƒ³ãƒ‰æ–‡å­—åˆ—ã‹ã‚‰ãƒ¢ãƒ¼ãƒ‰ã®ã‚·ãƒ³ãƒœãƒ«ã‚’å–ã‚Šå‡ºã™
   #
   # @return [Symbol]
   #
@@ -1251,14 +1251,14 @@ class Aozora2Html
     apply_rest_notes(command)
   end
 
-  # –T‹L‚ğ•À‚×‚é—p
+  # å‚è¨˜ã‚’ä¸¦ã¹ã‚‹ç”¨
   #
   def multiply(bouki, times)
     sep = "&nbsp;"
     ([bouki]*times).join(sep)
   end
 
-  # array‚ªƒ‹ƒr‚ğŠÜ‚ñ‚Å‚¢‚ê‚Î‚»‚ÌƒCƒ“ƒfƒbƒNƒX‚ğ•Ô‚·
+  # arrayãŒãƒ«ãƒ“ã‚’å«ã‚“ã§ã„ã‚Œã°ãã®ã‚¤ãƒ³ãƒ‡ãƒƒã‚¯ã‚¹ã‚’è¿”ã™
   #
   # @return [Integer, nil]
   #
@@ -1276,7 +1276,7 @@ class Aozora2Html
     end
   end
 
-  # rubyƒ^ƒO‚ÌÄ¶¬(–{‘Ì‚Írearrange_ruby)
+  # rubyã‚¿ã‚°ã®å†ç”Ÿæˆ(æœ¬ä½“ã¯rearrange_ruby)
   #
   # complex ruby wrap up utilities -- don't erase! we will use soon ...
   #
@@ -1285,7 +1285,7 @@ class Aozora2Html
     Aozora2Html::Tag::Ruby.new(self, target, upper, under)
   end
 
-  # rubyƒ^ƒO‚ÌÄŠ„‚è“–‚Ä
+  # rubyã‚¿ã‚°ã®å†å‰²ã‚Šå½“ã¦
   def rearrange_ruby(targets, upper_ruby, under_ruby = "")
     if include_ruby?(targets)
       new_targets = []
@@ -1456,9 +1456,9 @@ class Aozora2Html
     end
   end
 
-  # ‚­‚Ìš“_‚Ìˆ—
+  # ãã®å­—ç‚¹ã®å‡¦ç†
   #
-  # ‚­‚Ìš“_‚ÍŒ»ó‚»‚Ì‚Ü‚Üo—Í‚·‚é‚Ì‚Åƒtƒbƒ^‚Ìu•\‹L‚É‚Â‚¢‚Äv‚Åo—Í‚·‚é‚©‚Ç‚¤‚©‚Ìƒtƒ‰ƒOˆ—‚¾‚¯s‚¤
+  # ãã®å­—ç‚¹ã¯ç¾çŠ¶ãã®ã¾ã¾å‡ºåŠ›ã™ã‚‹ã®ã§ãƒ•ãƒƒã‚¿ã®ã€Œè¡¨è¨˜ã«ã¤ã„ã¦ã€ã§å‡ºåŠ›ã™ã‚‹ã‹ã©ã†ã‹ã®ãƒ•ãƒ©ã‚°å‡¦ç†ã ã‘è¡Œã†
   def assign_kunoji
     second = @stream.peek_char(0)
     case second
@@ -1476,7 +1476,7 @@ class Aozora2Html
     Aozora2Html::Tag::EditorNote.new(self, command)
   end
 
-  # b‚ª—ˆ‚½‚Æ‚«‚Í•¶ší‚ğ–³‹‚µ‚Äruby_buf‚ğç‚ç‚È‚«‚á‚¢‚¯‚È‚¢
+  # ï½œãŒæ¥ãŸã¨ãã¯æ–‡å­—ç¨®ã‚’ç„¡è¦–ã—ã¦ruby_bufã‚’å®ˆã‚‰ãªãã‚ƒã„ã‘ãªã„
   def apply_ruby
     @ruby_buf.protected = nil
     ruby, _raw = read_to_nest(RUBY_END_MARK)
@@ -1501,7 +1501,7 @@ class Aozora2Html
     nil
   end
 
-  # parse_body‚Ìƒtƒbƒ^”Å
+  # parse_bodyã®ãƒ•ãƒƒã‚¿ç‰ˆ
   def parse_tail
     char = read_char
     check = true
@@ -1537,14 +1537,14 @@ class Aozora2Html
     end
   end
 
-  # general_output‚Ìƒtƒbƒ^”Å
+  # general_outputã®ãƒ•ãƒƒã‚¿ç‰ˆ
   def tail_output
     @ruby_buf.dump_into(@buffer)
     string = @buffer.join
     @ruby_buf.clear
     @buffer = []
     string.gsub!("info@aozora.gr.jp",'<a href="mailto: info@aozora.gr.jp">info@aozora.gr.jp</a>')
-    string.gsub!("Â‹ó•¶ŒÉihttp://www.aozora.gr.jp/j".to_sjis){"<a href=\"http://www.aozora.gr.jp/\">#{$&}</a>"}
+    string.gsub!("é’ç©ºæ–‡åº«ï¼ˆhttp://www.aozora.gr.jp/ï¼‰".to_sjis){"<a href=\"http://www.aozora.gr.jp/\">#{$&}</a>"}
     if string.match(/(<br \/>$|<\/p>$|<\/h\d>$|<div.*>$|<\/div>$|^<[^>]*>$)/)
       @out.print string, "\r\n"
     else
@@ -1552,31 +1552,31 @@ class Aozora2Html
     end
   end
 
-  # `œ•\‹L‚É‚Â‚¢‚Ä`‚Åg—p‚µ‚½’‹L“™‚ğo—Í‚·‚é
+  # `â—è¡¨è¨˜ã«ã¤ã„ã¦`ã§ä½¿ç”¨ã—ãŸæ³¨è¨˜ç­‰ã‚’å‡ºåŠ›ã™ã‚‹
   def hyoki
     # <br /> times fix
-    @out.print "<br />\r\n</div>\r\n<div class=\"notation_notes\">\r\n<hr />\r\n<br />\r\nœ•\‹L‚É‚Â‚¢‚Ä<br />\r\n<ul>\r\n".to_sjis
-    @out.print "\t<li>‚±‚Ìƒtƒ@ƒCƒ‹‚Í W3C Š© XHTML1.1 ‚É‚»‚Á‚½Œ`®‚Åì¬‚³‚ê‚Ä‚¢‚Ü‚·B</li>\r\n".to_sjis
+    @out.print "<br />\r\n</div>\r\n<div class=\"notation_notes\">\r\n<hr />\r\n<br />\r\nâ—è¡¨è¨˜ã«ã¤ã„ã¦<br />\r\n<ul>\r\n".to_sjis
+    @out.print "\t<li>ã“ã®ãƒ•ã‚¡ã‚¤ãƒ«ã¯ W3C å‹§å‘Š XHTML1.1 ã«ãã£ãŸå½¢å¼ã§ä½œæˆã•ã‚Œã¦ã„ã¾ã™ã€‚</li>\r\n".to_sjis
     if @chuuki_table[:chuki]
-      @out.print "\t<li>m”cn‚ÍA“ü—ÍÒ‚É‚æ‚é’‚ğ•\‚·‹L†‚Å‚·B</li>\r\n".to_sjis
+      @out.print "\t<li>ï¼»ï¼ƒâ€¦ï¼½ã¯ã€å…¥åŠ›è€…ã«ã‚ˆã‚‹æ³¨ã‚’è¡¨ã™è¨˜å·ã§ã™ã€‚</li>\r\n".to_sjis
     end
     if @chuuki_table[:kunoji]
       if @chuuki_table[:dakutenkunoji]
-        @out.print "\t<li>u‚­‚Ìš“_v‚Íu#{KU}#{NOJI}v‚ÅAu‘÷“_•t‚«‚­‚Ìš“_v‚Íu#{KU}#{DAKUTEN}#{NOJI}v‚Å•\‚µ‚Ü‚µ‚½B</li>\r\n".to_sjis
+        @out.print "\t<li>ã€Œãã®å­—ç‚¹ã€ã¯ã€Œ#{KU}#{NOJI}ã€ã§ã€ã€Œæ¿ç‚¹ä»˜ããã®å­—ç‚¹ã€ã¯ã€Œ#{KU}#{DAKUTEN}#{NOJI}ã€ã§è¡¨ã—ã¾ã—ãŸã€‚</li>\r\n".to_sjis
       else
-        @out.print "\t<li>u‚­‚Ìš“_v‚Íu#{KU}#{NOJI}v‚Å•\‚µ‚Ü‚µ‚½B</li>\r\n".to_sjis
+        @out.print "\t<li>ã€Œãã®å­—ç‚¹ã€ã¯ã€Œ#{KU}#{NOJI}ã€ã§è¡¨ã—ã¾ã—ãŸã€‚</li>\r\n".to_sjis
       end
     elsif @chuuki_table[:dakutenkunoji]
-      @out.print "\t<li>u‘÷“_•t‚«‚­‚Ìš“_v‚Íu#{KU}#{DAKUTEN}#{NOJI}v‚Å•\‚µ‚Ü‚µ‚½B</li>\r\n".to_sjis
+      @out.print "\t<li>ã€Œæ¿ç‚¹ä»˜ããã®å­—ç‚¹ã€ã¯ã€Œ#{KU}#{DAKUTEN}#{NOJI}ã€ã§è¡¨ã—ã¾ã—ãŸã€‚</li>\r\n".to_sjis
     end
     if @chuuki_table[:newjis] && !Aozora2Html::Tag::EmbedGaiji.use_jisx0213
-      @out.print "\t<li>u‚­‚Ìš“_v‚ğ‚Ì‚¼‚­JIS X 0213‚É‚ ‚é•¶š‚ÍA‰æ‘œ‰»‚µ‚Ä–„‚ß‚İ‚Ü‚µ‚½B</li>\r\n".to_sjis
+      @out.print "\t<li>ã€Œãã®å­—ç‚¹ã€ã‚’ã®ããJIS X 0213ã«ã‚ã‚‹æ–‡å­—ã¯ã€ç”»åƒåŒ–ã—ã¦åŸ‹ã‚è¾¼ã¿ã¾ã—ãŸã€‚</li>\r\n".to_sjis
     end
     if @chuuki_table[:accent] && !Aozora2Html::Tag::Accent.use_jisx0213
-      @out.print "\t<li>ƒAƒNƒZƒ“ƒg•„†•t‚«ƒ‰ƒeƒ“•¶š‚ÍA‰æ‘œ‰»‚µ‚Ä–„‚ß‚İ‚Ü‚µ‚½B</li>\r\n".to_sjis
+      @out.print "\t<li>ã‚¢ã‚¯ã‚»ãƒ³ãƒˆç¬¦å·ä»˜ããƒ©ãƒ†ãƒ³æ–‡å­—ã¯ã€ç”»åƒåŒ–ã—ã¦åŸ‹ã‚è¾¼ã¿ã¾ã—ãŸã€‚</li>\r\n".to_sjis
     end
     if @images[0]
-      @out.print "\t<li>‚±‚Ìì•i‚É‚ÍAJIS X 0213‚É‚È‚¢AˆÈ‰º‚Ì•¶š‚ª—p‚¢‚ç‚ê‚Ä‚¢‚Ü‚·Bi”š‚ÍA’ê–{’†‚ÌoŒ»uƒy[ƒW-sv”Bj‚±‚ê‚ç‚Ì•¶š‚Í–{•¶“à‚Å‚Íu¦m”cnv‚ÌŒ`‚Å¦‚µ‚Ü‚µ‚½B</li>\r\n</ul>\r\n<br />\r\n\t\t<table class=\"gaiji_list\">\r\n".to_sjis
+      @out.print "\t<li>ã“ã®ä½œå“ã«ã¯ã€JIS X 0213ã«ãªã„ã€ä»¥ä¸‹ã®æ–‡å­—ãŒç”¨ã„ã‚‰ã‚Œã¦ã„ã¾ã™ã€‚ï¼ˆæ•°å­—ã¯ã€åº•æœ¬ä¸­ã®å‡ºç¾ã€Œãƒšãƒ¼ã‚¸-è¡Œã€æ•°ã€‚ï¼‰ã“ã‚Œã‚‰ã®æ–‡å­—ã¯æœ¬æ–‡å†…ã§ã¯ã€Œâ€»ï¼»ï¼ƒâ€¦ï¼½ã€ã®å½¢ã§ç¤ºã—ã¾ã—ãŸã€‚</li>\r\n</ul>\r\n<br />\r\n\t\t<table class=\"gaiji_list\">\r\n".to_sjis
       @images.each{|cell|
        k,*v = cell
        @out.print "			<tr>
@@ -1585,10 +1585,10 @@ class Aozora2Html
 				</td>
 				<td>&nbsp;&nbsp;</td>
 				<td>
-#{v.join("A")}				</td>
+#{v.join("ã€")}				</td>
 				<!--
 				<td>
-				@@<img src=\"../../../gaiji/others/xxxx.png\" alt=\"#{k}\" width=32 height=32 />
+				ã€€ã€€<img src=\"../../../gaiji/others/xxxx.png\" alt=\"#{k}\" width=32 height=32 />
 				</td>
 				-->
 			</tr>
@@ -1596,13 +1596,13 @@ class Aozora2Html
       }
       @out.print "\t\t</table>\r\n".to_sjis
     else
-      @out.print "</ul>\r\n" # <ul>“à‚É<li>ˆÈŠO‚ÌƒGƒŒƒƒ“ƒg‚ª—ˆ‚é‚Ì‚Í•s³‚È‚Ì‚ÅC³
+      @out.print "</ul>\r\n" # <ul>å†…ã«<li>ä»¥å¤–ã®ã‚¨ãƒ¬ãƒ¡ãƒ³ãƒˆãŒæ¥ã‚‹ã®ã¯ä¸æ­£ãªã®ã§ä¿®æ­£
     end
     @out.print "</div>\r\n"
   end
 end
 
 if $0 == __FILE__
-  # todo: ˆø”ƒ`ƒFƒbƒN‚Æ‚©
+  # todo: å¼•æ•°ãƒã‚§ãƒƒã‚¯ã¨ã‹
   Aozora2Html.new($*[0],$*[1]).process
 end

--- a/lib/t2hs.rb
+++ b/lib/t2hs.rb
@@ -105,11 +105,11 @@ class Aozora2Html
   PAT_BOUKI = /#{"「(.)」の傍記".to_sjis}/
   PAT_CHARSIZE = /#{"(.*)段階(..)な文字".to_sjis}/
 
-  DYNAMIC_CONTENTS = "<div id=\"card\">\r\n<hr />\r\n<br />\r\n" +
-                     "<a href=\"JavaScript:goLibCard();\" id=\"goAZLibCard\">●図書カード</a>" +
-                     "<script type=\"text/javascript\" src=\"../../contents.js\"></script>\r\n" +
-                     "<script type=\"text/javascript\" src=\"../../golibcard.js\"></script>\r\n" +
-                     "</div>".to_sjis
+  DYNAMIC_CONTENTS = ("<div id=\"card\">\r\n<hr />\r\n<br />\r\n" +
+                      "<a href=\"JavaScript:goLibCard();\" id=\"goAZLibCard\">●図書カード</a>" +
+                      "<script type=\"text/javascript\" src=\"../../contents.js\"></script>\r\n" +
+                      "<script type=\"text/javascript\" src=\"../../golibcard.js\"></script>\r\n" +
+                      "</div>").to_sjis
 
   # KUNOJI = ["18e518f5"].pack("h*")
   # utf8 ["fecbf8fecbcb"].pack("h*")

--- a/lib/t2hs.rb
+++ b/lib/t2hs.rb
@@ -29,6 +29,9 @@ class Aozora2Html
   SIZE_SMALL = "小"
   SIZE_MIDDLE = "中"
   SIZE_LARGE = "大"
+  TEIHON_MARK = "底本："
+  COMMAND_BEGIN = "［"
+  ACCENT_BEGIN = "〔"
   AOZORABUNKO = "青空文庫"
   #PAT_EDITOR = /[校訂|編|編集|編集校訂|校訂編集]$/
   PAT_EDITOR = /(校訂|編|編集)$/
@@ -389,16 +392,16 @@ class Aozora2Html
     char = read_char
     check = true
     case char
-    when "〔"
+    when ACCENT_BEGIN
       check = false
       char = read_accent
-    when "底"
+    when TEIHON_MARK[0]
       if @buffer.length == 0
         ending_check
       end
     when GAIJI_MARK
       char = dispatch_gaiji
-    when "［"
+    when COMMAND_BEGIN
       char = dispatch_aozora_command
     when KU
       assign_kunoji
@@ -431,7 +434,7 @@ class Aozora2Html
   #
   def ending_check
     # `底本：`でフッタ(:tail)に遷移
-    if @stream.peek_char(0) == "本" and @stream.peek_char(1) == "："
+    if @stream.peek_char(0) == TEIHON_MARK[1] and @stream.peek_char(1) == TEIHON_MARK[2]
       @section = :tail
       ensure_close
       @out.print "</div>\r\n<div class=\"bibliographical_information\">\r\n<hr />\r\n<br />\r\n"
@@ -699,7 +702,7 @@ class Aozora2Html
 
   def dispatch_gaiji
     # 「※」の次が「［」でなければ外字ではない
-    if @stream.peek_char(0) !=  "［"
+    if @stream.peek_char(0) !=  COMMAND_BEGIN
       return GAIJI_MARK
     end
 
@@ -723,7 +726,7 @@ class Aozora2Html
   def dispatch_aozora_command
     # 「［」の次が「＃」でなければ注記ではない
     if @stream.peek_char(0) != "＃"
-      return "［"
+      return COMMAND_BEGIN
     end
 
     # 「＃」を読み捨てる
@@ -1462,14 +1465,14 @@ class Aozora2Html
     char = read_char
     check = true
     case char
-    when "〔"
+    when ACCENT_BEGIN
       check = false
       char = read_accent
     when @endchar
       throw :terminate
     when GAIJI_MARK
       char = dispatch_gaiji
-    when "［"
+    when COMMAND_BEGIN
       char = dispatch_aozora_command
     when KU
       assign_kunoji

--- a/lib/t2hs.rb
+++ b/lib/t2hs.rb
@@ -25,91 +25,91 @@ class Aozora2Html
   KU = ["18e5"].pack("h*").force_encoding("shift_jis")
   NOJI = ["18f5"].pack("h*").force_encoding("shift_jis")
   DAKUTEN = ["18d8"].pack("h*").force_encoding("shift_jis")
-  GAIJI_MARK = "※"
-  IGETA_MARK = "＃"
-  RUBY_BEGIN_MARK = "《"
-  RUBY_END_MARK = "》"
-  PAREN_BEGIN_MARK = "（"
-  PAREN_END_MARK = "）"
-  SIZE_SMALL = "小"
-  SIZE_MIDDLE = "中"
-  SIZE_LARGE = "大"
-  TEIHON_MARK = "底本："
-  COMMAND_BEGIN = "［"
-  COMMAND_END = "］"
-  ACCENT_BEGIN = "〔"
-  ACCENT_END = "〕"
-  AOZORABUNKO = "青空文庫"
+  GAIJI_MARK = "※".to_sjis
+  IGETA_MARK = "＃".to_sjis
+  RUBY_BEGIN_MARK = "《".to_sjis
+  RUBY_END_MARK = "》".to_sjis
+  PAREN_BEGIN_MARK = "（".to_sjis
+  PAREN_END_MARK = "）".to_sjis
+  SIZE_SMALL = "小".to_sjis
+  SIZE_MIDDLE = "中".to_sjis
+  SIZE_LARGE = "大".to_sjis
+  TEIHON_MARK = "底本：".to_sjis
+  COMMAND_BEGIN = "［".to_sjis
+  COMMAND_END = "］".to_sjis
+  ACCENT_BEGIN = "〔".to_sjis
+  ACCENT_END = "〕".to_sjis
+  AOZORABUNKO = "青空文庫".to_sjis
   #PAT_EDITOR = /[校訂|編|編集|編集校訂|校訂編集]$/
-  PAT_EDITOR = /(校訂|編|編集)$/
-  PAT_HENYAKU = /編訳$/
-  PAT_TRANSLATOR = /訳$/
-  RUBY_PREFIX = "｜"
-  PAT_RUBY = /《.*?》/
-  PAT_DIRECTION = /(右|左|上|下)に(.*)/
-  PAT_REF = /^「.+」/
-  CHUUKI_COMMAND = "注記付き"
-  TCY_COMMAND = "縦中横"
-  KEIGAKOMI_COMMAND = "罫囲み"
-  YOKOGUMI_COMMAND = "横組み"
-  CAPTION_COMMAND = "キャプション"
-  WARIGAKI_COMMAND = "割書"
-  KAERITEN_COMMAND = "返り点"
-  KUNTEN_OKURIGANA_COMMAND = "訓点送り仮名"
-  MIDASHI_COMMAND = "見出し"
-  OMIDASHI_COMMAND = "大見出し"
-  NAKAMIDASHI_COMMAND = "中見出し"
-  KOMIDASHI_COMMAND = "小見出し"
-  DOGYO_OMIDASHI_COMMAND = "同行大見出し"
-  DOGYO_NAKAMIDASHI_COMMAND = "同行中見出し"
-  DOGYO_KOMIDASHI_COMMAND = "同行小見出し"
-  MADO_OMIDASHI_COMMAND = "窓大見出し"
-  MADO_NAKAMIDASHI_COMMAND = "窓中見出し"
-  MADO_KOMIDASHI_COMMAND = "窓小見出し"
-  LEFT_MARK = "左"
-  UNDER_MARK = "下"
-  OVER_MARK = "上"
-  MAIN_MARK = "本文"
-  END_MARK = "終わり"
-  TEN_MARK = "点"
-  SEN_MARK = "線"
-  OPEN_MARK = "ここから"
-  CLOSE_MARK = "ここで"
-  MADE_MARK = "まで"
-  DOGYO_MARK = "同行"
-  MADO_MARK = "窓"
-  JIAGE_COMMAND = "字上げ"
-  JISAGE_COMMAND = "字下げ"
-  PHOTO_COMMAND = "写真"
-  ORIKAESHI_COMMAND = "折り返して"
-  ONELINE_COMMAND = "この行"
-  NON_0213_GAIJI = "非0213外字"
-  WARICHU_COMMAND = "割り注"
-  TENTSUKI_COMMAND = "天付き"
-  PAT_REST_NOTES = /(左|下)に「(.*)」の(ルビ|注記|傍記)/
-  PAT_KUTEN = /「※」[は|の]/
-  PAT_KUTEN_DUAL = /※.*※/
-  PAT_GAIJI = /(?:＃)(.*)(?:、)(.*)/
-  PAT_KAERITEN = /^([一二三四五六七八九十レ上中下甲乙丙丁天地人]+)$/
-  PAT_OKURIGANA = /^（(.+)）$/
-  PAT_REMOVE_OKURIGANA = /[（）]/
-  PAT_CHITSUKI = /(地付き|字上げ)(終わり)*$/
-  PAT_ORIKAESHI_JISAGE = /折り返して(\d*)字下げ/
-  PAT_ORIKAESHI_JISAGE2 = /(\d*)字下げ、折り返して(\d*)字下げ/
-  PAT_JI_LEN = /([0-9]+)字/
-  PAT_INLINE_RUBY = "「(.*)」の注記付き"
-  PAT_IMAGE = /(.*)（(fig.+\.png)(、横([0-9]+)×縦([0-9]+))*）入る/
-  PAT_FRONTREF = /「([^「」]*(?:「.+」)*[^「」]*)」[にはの](「.+」の)*(.+)/
-  PAT_RUBY_DIR = /(左|下)に「([^」]*)」の(ルビ|注記)/
-  PAT_CHUUKI = /「(.+?)」の注記/
-  PAT_BOUKI = /「(.)」の傍記/
-  PAT_CHARSIZE = /(.*)段階(..)な文字/
+  PAT_EDITOR = "(校訂|編|編集)$".to_sjis
+  PAT_HENYAKU = "編訳$".to_sjis
+  PAT_TRANSLATOR = "訳$".to_sjis
+  RUBY_PREFIX = "｜".to_sjis
+  PAT_RUBY = /#{"《.*?》".to_sjis}/
+  PAT_DIRECTION = "(右|左|上|下)に(.*)".to_sjis
+  PAT_REF = "^「.+」".to_sjis
+  CHUUKI_COMMAND = "注記付き".to_sjis
+  TCY_COMMAND = "縦中横".to_sjis
+  KEIGAKOMI_COMMAND = "罫囲み".to_sjis
+  YOKOGUMI_COMMAND = "横組み".to_sjis
+  CAPTION_COMMAND = "キャプション".to_sjis
+  WARIGAKI_COMMAND = "割書".to_sjis
+  KAERITEN_COMMAND = "返り点".to_sjis
+  KUNTEN_OKURIGANA_COMMAND = "訓点送り仮名".to_sjis
+  MIDASHI_COMMAND = "見出し".to_sjis
+  OMIDASHI_COMMAND = "大見出し".to_sjis
+  NAKAMIDASHI_COMMAND = "中見出し".to_sjis
+  KOMIDASHI_COMMAND = "小見出し".to_sjis
+  DOGYO_OMIDASHI_COMMAND = "同行大見出し".to_sjis
+  DOGYO_NAKAMIDASHI_COMMAND = "同行中見出し".to_sjis
+  DOGYO_KOMIDASHI_COMMAND = "同行小見出し".to_sjis
+  MADO_OMIDASHI_COMMAND = "窓大見出し".to_sjis
+  MADO_NAKAMIDASHI_COMMAND = "窓中見出し".to_sjis
+  MADO_KOMIDASHI_COMMAND = "窓小見出し".to_sjis
+  LEFT_MARK = "左".to_sjis
+  UNDER_MARK = "下".to_sjis
+  OVER_MARK = "上".to_sjis
+  MAIN_MARK = "本文".to_sjis
+  END_MARK = "終わり".to_sjis
+  TEN_MARK = "点".to_sjis
+  SEN_MARK = "線".to_sjis
+  OPEN_MARK = "ここから".to_sjis
+  CLOSE_MARK = "ここで".to_sjis
+  MADE_MARK = "まで".to_sjis
+  DOGYO_MARK = "同行".to_sjis
+  MADO_MARK = "窓".to_sjis
+  JIAGE_COMMAND = "字上げ".to_sjis
+  JISAGE_COMMAND = "字下げ".to_sjis
+  PHOTO_COMMAND = "写真".to_sjis
+  ORIKAESHI_COMMAND = "折り返して".to_sjis
+  ONELINE_COMMAND = "この行".to_sjis
+  NON_0213_GAIJI = "非0213外字".to_sjis
+  WARICHU_COMMAND = "割り注".to_sjis
+  TENTSUKI_COMMAND = "天付き".to_sjis
+  PAT_REST_NOTES = "(左|下)に「(.*)」の(ルビ|注記|傍記)".to_sjis
+  PAT_KUTEN = /#{"「※」[は|の]".to_sjis}/
+  PAT_KUTEN_DUAL = "※.*※".to_sjis
+  PAT_GAIJI = "(?:＃)(.*)(?:、)(.*)".to_sjis
+  PAT_KAERITEN = "^([一二三四五六七八九十レ上中下甲乙丙丁天地人]+)$".to_sjis
+  PAT_OKURIGANA = "^（(.+)）$".to_sjis
+  PAT_REMOVE_OKURIGANA = /#{"[（）]".to_sjis}/
+  PAT_CHITSUKI = /#{"(地付き|字上げ)(終わり)*$".to_sjis}/
+  PAT_ORIKAESHI_JISAGE = "折り返して(\d*)字下げ".to_sjis
+  PAT_ORIKAESHI_JISAGE2 = "(\d*)字下げ、折り返して(\d*)字下げ".to_sjis
+  PAT_JI_LEN = "([0-9]+)字".to_sjis
+  PAT_INLINE_RUBY = "「(.*)」の注記付き".to_sjis
+  PAT_IMAGE = "(.*)（(fig.+\.png)(、横([0-9]+)×縦([0-9]+))*）入る".to_sjis
+  PAT_FRONTREF = "「([^「」]*(?:「.+」)*[^「」]*)」[にはの](「.+」の)*(.+)".to_sjis
+  PAT_RUBY_DIR = "(左|下)に「([^」]*)」の(ルビ|注記)".to_sjis
+  PAT_CHUUKI = /#{"「(.+?)」の注記".to_sjis}/
+  PAT_BOUKI = /#{"「(.)」の傍記".to_sjis}/
+  PAT_CHARSIZE = /#{"(.*)段階(..)な文字".to_sjis}/
 
   DYNAMIC_CONTENTS = "<div id=\"card\">\r\n<hr />\r\n<br />\r\n" +
                      "<a href=\"JavaScript:goLibCard();\" id=\"goAZLibCard\">●図書カード</a>" +
                      "<script type=\"text/javascript\" src=\"../../contents.js\"></script>\r\n" +
                      "<script type=\"text/javascript\" src=\"../../golibcard.js\"></script>\r\n" +
-                     "</div>"
+                     "</div>".to_sjis
 
   # KUNOJI = ["18e518f5"].pack("h*")
   # utf8 ["fecbf8fecbcb"].pack("h*")
@@ -124,24 +124,24 @@ class Aozora2Html
   JIS2UCS = loader.load("../yml/jis2ucs.yml")
 
   INDENT_TYPE = {
-    :jisage => "字下げ",
-    :chitsuki => "地付き",
-    :midashi => "見出し",
-    :jizume => "字詰め",
-    :yokogumi => "横組み",
-    :keigakomi => "罫囲み",
-    :caption => "キャプション",
-    :futoji => "太字",
-    :shatai => "斜体",
-    :dai => "大きな文字",
-    :sho => "小さな文字",
+    :jisage => "字下げ".to_sjis,
+    :chitsuki => "地付き".to_sjis,
+    :midashi => "見出し".to_sjis,
+    :jizume => "字詰め".to_sjis,
+    :yokogumi => "横組み".to_sjis,
+    :keigakomi => "罫囲み".to_sjis,
+    :caption => "キャプション".to_sjis,
+    :futoji => "太字".to_sjis,
+    :shatai => "斜体".to_sjis,
+    :dai => "大きな文字".to_sjis,
+    :sho => "小さな文字".to_sjis,
   }
 
   DAKUTEN_KATAKANA_TABLE = {
-    "2" => "ワ゛",
-    "3" => "ヰ゛",
-    "4" => "ヱ゛",
-    "5" => "ヲ゛",
+    "2" => "ワ゛".to_sjis,
+    "3" => "ヰ゛".to_sjis,
+    "4" => "ヱ゛".to_sjis,
+    "5" => "ヲ゛".to_sjis,
   }
 
   def initialize(input, output)
@@ -1544,7 +1544,7 @@ class Aozora2Html
     @ruby_buf.clear
     @buffer = []
     string.gsub!("info@aozora.gr.jp",'<a href="mailto: info@aozora.gr.jp">info@aozora.gr.jp</a>')
-    string.gsub!("青空文庫（http://www.aozora.gr.jp/）"){"<a href=\"http://www.aozora.gr.jp/\">#{$&}</a>"}
+    string.gsub!("青空文庫（http://www.aozora.gr.jp/）".to_sjis){"<a href=\"http://www.aozora.gr.jp/\">#{$&}</a>"}
     if string.match(/(<br \/>$|<\/p>$|<\/h\d>$|<div.*>$|<\/div>$|^<[^>]*>$)/)
       @out.print string, "\r\n"
     else
@@ -1555,28 +1555,28 @@ class Aozora2Html
   # `●表記について`で使用した注記等を出力する
   def hyoki
     # <br /> times fix
-    @out.print "<br />\r\n</div>\r\n<div class=\"notation_notes\">\r\n<hr />\r\n<br />\r\n●表記について<br />\r\n<ul>\r\n"
-    @out.print "\t<li>このファイルは W3C 勧告 XHTML1.1 にそった形式で作成されています。</li>\r\n"
+    @out.print "<br />\r\n</div>\r\n<div class=\"notation_notes\">\r\n<hr />\r\n<br />\r\n●表記について<br />\r\n<ul>\r\n".to_sjis
+    @out.print "\t<li>このファイルは W3C 勧告 XHTML1.1 にそった形式で作成されています。</li>\r\n".to_sjis
     if @chuuki_table[:chuki]
-      @out.print "\t<li>［＃…］は、入力者による注を表す記号です。</li>\r\n"
+      @out.print "\t<li>［＃…］は、入力者による注を表す記号です。</li>\r\n".to_sjis
     end
     if @chuuki_table[:kunoji]
       if @chuuki_table[:dakutenkunoji]
-        @out.print "\t<li>「くの字点」は「#{KU}#{NOJI}」で、「濁点付きくの字点」は「#{KU}#{DAKUTEN}#{NOJI}」で表しました。</li>\r\n"
+        @out.print "\t<li>「くの字点」は「#{KU}#{NOJI}」で、「濁点付きくの字点」は「#{KU}#{DAKUTEN}#{NOJI}」で表しました。</li>\r\n".to_sjis
       else
-        @out.print "\t<li>「くの字点」は「#{KU}#{NOJI}」で表しました。</li>\r\n"
+        @out.print "\t<li>「くの字点」は「#{KU}#{NOJI}」で表しました。</li>\r\n".to_sjis
       end
     elsif @chuuki_table[:dakutenkunoji]
-      @out.print "\t<li>「濁点付きくの字点」は「#{KU}#{DAKUTEN}#{NOJI}」で表しました。</li>\r\n"
+      @out.print "\t<li>「濁点付きくの字点」は「#{KU}#{DAKUTEN}#{NOJI}」で表しました。</li>\r\n".to_sjis
     end
     if @chuuki_table[:newjis] && !Aozora2Html::Tag::EmbedGaiji.use_jisx0213
-      @out.print "\t<li>「くの字点」をのぞくJIS X 0213にある文字は、画像化して埋め込みました。</li>\r\n"
+      @out.print "\t<li>「くの字点」をのぞくJIS X 0213にある文字は、画像化して埋め込みました。</li>\r\n".to_sjis
     end
     if @chuuki_table[:accent] && !Aozora2Html::Tag::Accent.use_jisx0213
-      @out.print "\t<li>アクセント符号付きラテン文字は、画像化して埋め込みました。</li>\r\n"
+      @out.print "\t<li>アクセント符号付きラテン文字は、画像化して埋め込みました。</li>\r\n".to_sjis
     end
     if @images[0]
-      @out.print "\t<li>この作品には、JIS X 0213にない、以下の文字が用いられています。（数字は、底本中の出現「ページ-行」数。）これらの文字は本文内では「※［＃…］」の形で示しました。</li>\r\n</ul>\r\n<br />\r\n\t\t<table class=\"gaiji_list\">\r\n"
+      @out.print "\t<li>この作品には、JIS X 0213にない、以下の文字が用いられています。（数字は、底本中の出現「ページ-行」数。）これらの文字は本文内では「※［＃…］」の形で示しました。</li>\r\n</ul>\r\n<br />\r\n\t\t<table class=\"gaiji_list\">\r\n".to_sjis
       @images.each{|cell|
        k,*v = cell
        @out.print "			<tr>
@@ -1592,9 +1592,9 @@ class Aozora2Html
 				</td>
 				-->
 			</tr>
-"
+".to_sjis
       }
-      @out.print "\t\t</table>\r\n"
+      @out.print "\t\t</table>\r\n".to_sjis
     else
       @out.print "</ul>\r\n" # <ul>内に<li>以外のエレメントが来るのは不正なので修正
     end

--- a/lib/t2hs.rb
+++ b/lib/t2hs.rb
@@ -396,7 +396,7 @@ class Aozora2Html
       if @buffer.length == 0
         ending_check
       end
-    when "※"
+    when GAIJI_MARK
       char = dispatch_gaiji
     when "［"
       char = dispatch_aozora_command
@@ -551,7 +551,7 @@ class Aozora2Html
         tail.unshift(s.close_tag)
       elsif s.is_a?(Aozora2Html::Tag::UnEmbedGaiji) and !s.escaped?
         # 消してあった※を復活させて
-        @out.print "※"
+        @out.print GAIJI_MARK
       end
       @out.print s.to_s
     end
@@ -700,7 +700,7 @@ class Aozora2Html
   def dispatch_gaiji
     # 「※」の次が「［」でなければ外字ではない
     if @stream.peek_char(0) !=  "［"
-      return "※"
+      return GAIJI_MARK
     end
 
     # 「［」を読み捨てる
@@ -1444,7 +1444,7 @@ class Aozora2Html
     notes = []
     @ruby_buf.each do |token|
       if token.is_a?(Aozora2Html::Tag::UnEmbedGaiji)
-        ans.concat("※")
+        ans.concat(GAIJI_MARK)
         token.escape!
         notes.push(token)
       else
@@ -1467,7 +1467,7 @@ class Aozora2Html
       char = read_accent
     when @endchar
       throw :terminate
-    when "※"
+    when GAIJI_MARK
       char = dispatch_gaiji
     when "［"
       char = dispatch_aozora_command

--- a/lib/t2hs.rb
+++ b/lib/t2hs.rb
@@ -692,16 +692,6 @@ class Aozora2Html
     end
   end
 
-  def convert_japanese_number(command)
-    tmp = command.tr("０-９", "0-9")
-    tmp.tr!("一二三四五六七八九〇","1234567890")
-    tmp.gsub!(/(\d)十(\d)/){"#{$1}#{$2}"}
-    tmp.gsub!(/(\d)十/){"#{$1}0"}
-    tmp.gsub!(/十(\d)/){"1#{$1}"}
-    tmp.gsub!(/十/,"10")
-    tmp
-  end
-
   def kuten2png(substring)
     desc = substring.gsub(/「※」[は|の]/,"")
     match = desc.match(/[12]\-\d{1,2}\-\d{1,2}/)
@@ -804,7 +794,7 @@ class Aozora2Html
       general_output
     end
     @noprint = true # always no print
-    command = convert_japanese_number(command)
+    command = Utils.convert_japanese_number(command)
     if command.match(/天付き/)
       width = command.match(/折り返して(\d*)字下げ/)[1]
       tag = '<div class="burasage" style="margin-left: ' + width + 'em; text-indent: -' + width  + 'em;">'
@@ -820,7 +810,7 @@ class Aozora2Html
   end
 
   def jisage_width(command)
-    convert_japanese_number(command).match(/(\d*)(?:字下げ)/)[1]
+    Utils.convert_japanese_number(command).match(/(\d*)(?:字下げ)/)[1]
   end
 
   def apply_jisage(command)
@@ -864,7 +854,7 @@ class Aozora2Html
   end
 
   def chitsuki_length(command)
-    command = convert_japanese_number(command)
+    command = Utils.convert_japanese_number(command)
     if match = command.match(/([0-9]+)字/)
       match[1]
     else
@@ -941,7 +931,7 @@ class Aozora2Html
   end
 
   def apply_jizume(command)
-    w = convert_japanese_number(command).match(/(\d*)(?:字詰め)/)[1]
+    w = Utils.convert_japanese_number(command).match(/(\d*)(?:字詰め)/)[1]
     @indent_stack.push(:jizume)
     Aozora2Html::Tag::Jizume.new(self, w)
   end
@@ -1012,7 +1002,7 @@ class Aozora2Html
     when /(.*)段階(..)な文字/
       @style_stack.push([command,'</span>'])
       _whole, nest, style = command.match(/(.*)段階(..)な文字/).to_a
-      times = convert_japanese_number(nest).to_i
+      times = Utils.convert_japanese_number(nest).to_i
       daisho = detect_style_size(style)
       html_class = daisho.to_s + times.to_s
       size = Utils.create_font_size(times, daisho)
@@ -1136,7 +1126,7 @@ class Aozora2Html
       end
       daisho = detect_style_size(style)
       push_block_tag(Aozora2Html::Tag::FontSize.new(self,
-                                                    convert_japanese_number(nest).to_i,
+                                                    Utils.convert_japanese_number(nest).to_i,
                                                     daisho),
                      match)
       @indent_stack.push(daisho)
@@ -1383,7 +1373,7 @@ class Aozora2Html
     elsif command.match(/(.*)段階(..)な文字/)
       _whole, nest, style = command.match(/(.*)段階(..)な文字/).to_a
       Aozora2Html::Tag::InlineFontSize.new(self,targets,
-                                           convert_japanese_number(nest).to_i,
+                                           Utils.convert_japanese_number(nest).to_i,
                                            detect_style_size(style))
     elsif command.match(/(左|下)に「([^」]*)」の(ルビ|注記)/)
       _whole, _dir, under = command.match(/(左|下)に「([^」]*)」の(ルビ|注記)/).to_a

--- a/lib/t2hs.rb
+++ b/lib/t2hs.rb
@@ -414,7 +414,7 @@ class Aozora2Html
       @ruby_buf.protected = true
     when @endchar
       # suddenly finished the file
-      puts "警告(#{line_number}行目):予期せぬファイル終端"
+      puts I18n.t(:warn_unexpected_terminator, line_number)
       throw :terminate
     when nil
       # noop
@@ -1015,7 +1015,7 @@ class Aozora2Html
         push_chars("<#{found[1]} class=\"#{filter.call(found[0])}\">")
       else
         if $DEBUG
-          puts "警告(#{line_number}行目):「#{key}」は未対応のコマンドのため無視します"
+          puts I18n.t(:warn_undefined_command, line_number, key)
         end
         nil
       end

--- a/lib/t2hs.rb
+++ b/lib/t2hs.rb
@@ -94,11 +94,11 @@ class Aozora2Html
   PAT_OKURIGANA = "^（(.+)）$".to_sjis
   PAT_REMOVE_OKURIGANA = /#{"[（）]".to_sjis}/
   PAT_CHITSUKI = /#{"(地付き|字上げ)(終わり)*$".to_sjis}/
-  PAT_ORIKAESHI_JISAGE = "折り返して(\d*)字下げ".to_sjis
-  PAT_ORIKAESHI_JISAGE2 = "(\d*)字下げ、折り返して(\d*)字下げ".to_sjis
+  PAT_ORIKAESHI_JISAGE = "折り返して(\\d*)字下げ".to_sjis
+  PAT_ORIKAESHI_JISAGE2 = "(\\d*)字下げ、折り返して(\\d*)字下げ".to_sjis
   PAT_JI_LEN = "([0-9]+)字".to_sjis
   PAT_INLINE_RUBY = "「(.*)」の注記付き".to_sjis
-  PAT_IMAGE = "(.*)（(fig.+\.png)(、横([0-9]+)×縦([0-9]+))*）入る".to_sjis
+  PAT_IMAGE = "(.*)（(fig.+\\.png)(、横([0-9]+)×縦([0-9]+))*）入る".to_sjis
   PAT_FRONTREF = "「([^「」]*(?:「.+」)*[^「」]*)」[にはの](「.+」の)*(.+)".to_sjis
   PAT_RUBY_DIR = "(左|下)に「([^」]*)」の(ルビ|注記)".to_sjis
   PAT_CHUUKI = /#{"「(.+?)」の注記".to_sjis}/
@@ -983,7 +983,7 @@ class Aozora2Html
   end
 
   def detect_style_size(style)
-    if style.match("小")
+    if style.match("小".to_sjis)
       :sho
     else
       :dai
@@ -1562,12 +1562,12 @@ class Aozora2Html
     end
     if @chuuki_table[:kunoji]
       if @chuuki_table[:dakutenkunoji]
-        @out.print "\t<li>「くの字点」は「#{KU}#{NOJI}」で、「濁点付きくの字点」は「#{KU}#{DAKUTEN}#{NOJI}」で表しました。</li>\r\n".to_sjis
+        @out.printf("\t<li>「くの字点」は「%s」で、「濁点付きくの字点」は「%s」で表しました。</li>\r\n".to_sjis, KU+NOJI, KU+DAKUTEN+NOJI)
       else
-        @out.print "\t<li>「くの字点」は「#{KU}#{NOJI}」で表しました。</li>\r\n".to_sjis
+        @out.printf("\t<li>「くの字点」は「%s」で表しました。</li>\r\n".to_sjis, KU+NOJI)
       end
     elsif @chuuki_table[:dakutenkunoji]
-      @out.print "\t<li>「濁点付きくの字点」は「#{KU}#{DAKUTEN}#{NOJI}」で表しました。</li>\r\n".to_sjis
+      @out.printf("\t<li>「濁点付きくの字点」は「%s」で表しました。</li>\r\n".to_sjis, KU+DAKUTEN+NOJI)
     end
     if @chuuki_table[:newjis] && !Aozora2Html::Tag::EmbedGaiji.use_jisx0213
       @out.print "\t<li>「くの字点」をのぞくJIS X 0213にある文字は、画像化して埋め込みました。</li>\r\n".to_sjis
@@ -1579,16 +1579,17 @@ class Aozora2Html
       @out.print "\t<li>この作品には、JIS X 0213にない、以下の文字が用いられています。（数字は、底本中の出現「ページ-行」数。）これらの文字は本文内では「※［＃…］」の形で示しました。</li>\r\n</ul>\r\n<br />\r\n\t\t<table class=\"gaiji_list\">\r\n".to_sjis
       @images.each{|cell|
        k,*v = cell
+        vs = v.join("、".to_sjis)
        @out.print "			<tr>
 				<td>
 				#{k}
 				</td>
 				<td>&nbsp;&nbsp;</td>
 				<td>
-#{v.join("、")}				</td>
+#{vs}				</td>
 				<!--
 				<td>
-				　　<img src=\"../../../gaiji/others/xxxx.png\" alt=\"#{k}\" width=32 height=32 />
+				    <img src=\"../../../gaiji/others/xxxx.png\" alt=\"#{k}\" width=32 height=32 />
 				</td>
 				-->
 			</tr>

--- a/test/test_aozora2html.rb
+++ b/test/test_aozora2html.rb
@@ -352,6 +352,28 @@ class Aozora2HtmlTest < Test::Unit::TestCase
     end
   end
 
+  def test_command_do
+    input = StringIO.new("［＃ここから太字］\r\nテスト。\r\n［＃ここで太字終わり］\r\n".encode("shift_jis"))
+    output = StringIO.new
+    parser = Aozora2Html.new(input, output)
+    out = StringIO.new
+    $stdout = out
+    _message = nil
+    begin
+      9.times do
+        parser.parse_body
+      end
+    rescue Aozora2Html::Error => e
+      _message = e.message.encode("utf-8")
+    ensure
+      $stdout = STDOUT
+      output.seek(0)
+      out_text = output.read
+      assert_equal "<div class=\"futoji\">\r\nテスト。<br />\r\n</div>\r\n", out_text
+    end
+  end
+
+
   def teardown
   end
 end

--- a/test/test_aozora2html.rb
+++ b/test/test_aozora2html.rb
@@ -295,7 +295,7 @@ class Aozora2HtmlTest < Test::Unit::TestCase
     parser = Aozora2Html.new(input, output)
     out = StringIO.new
     $stdout = out
-    message = nil
+    _message = nil
     begin
       parser.parse_body
       parser.parse_body
@@ -303,7 +303,7 @@ class Aozora2HtmlTest < Test::Unit::TestCase
       parser.parse_body
       parser.parse_body
     rescue Aozora2Html::Error => e
-      message = e.message.encode("utf-8")
+      _message = e.message.encode("utf-8")
     ensure
       $stdout = STDOUT
       output.seek(0)

--- a/test/test_aozora2html.rb
+++ b/test/test_aozora2html.rb
@@ -289,6 +289,29 @@ class Aozora2HtmlTest < Test::Unit::TestCase
     end
   end
 
+  def test_ending_check
+    input = StringIO.new("本文\r\n\r\n底本：test\r\n".encode("shift_jis"))
+    output = StringIO.new
+    parser = Aozora2Html.new(input, output)
+    out = StringIO.new
+    $stdout = out
+    message = nil
+    begin
+      parser.parse_body
+      parser.parse_body
+      parser.parse_body
+      parser.parse_body
+      parser.parse_body
+    rescue Aozora2Html::Error => e
+      message = e.message.encode("utf-8")
+    ensure
+      $stdout = STDOUT
+      output.seek(0)
+      out_text = output.read
+      assert_equal "本文<br />\r\n<br />\r\n</div>\r\n<div class=\"bibliographical_information\">\r\n<hr />\r\n<br />\r\n", out_text
+    end
+  end
+
   def test_invalid_closing
     input = StringIO.new("［＃ここで太字終わり］\r\n".encode("shift_jis"))
     output = StringIO.new

--- a/test/test_aozora2html.rb
+++ b/test/test_aozora2html.rb
@@ -177,19 +177,19 @@ class Aozora2HtmlTest < Test::Unit::TestCase
 
   def test_convert_japanese_number
     assert_equal "3字下げ",
-                 @parser.convert_japanese_number("三字下げ".encode("shift_jis")).encode("utf-8")
+                 Aozora2Html::Utils.convert_japanese_number("三字下げ".encode("shift_jis")).encode("utf-8")
     assert_equal "10字下げ",
-                 @parser.convert_japanese_number("十字下げ".encode("shift_jis")).encode("utf-8")
+                 Aozora2Html::Utils.convert_japanese_number("十字下げ".encode("shift_jis")).encode("utf-8")
     assert_equal "12字下げ",
-                 @parser.convert_japanese_number("十二字下げ".encode("shift_jis")).encode("utf-8")
+                 Aozora2Html::Utils.convert_japanese_number("十二字下げ".encode("shift_jis")).encode("utf-8")
     assert_equal "20字下げ",
-                 @parser.convert_japanese_number("二十字下げ".encode("shift_jis")).encode("utf-8")
+                 Aozora2Html::Utils.convert_japanese_number("二十字下げ".encode("shift_jis")).encode("utf-8")
     assert_equal "20字下げ",
-                 @parser.convert_japanese_number("二〇字下げ".encode("shift_jis")).encode("utf-8")
+                 Aozora2Html::Utils.convert_japanese_number("二〇字下げ".encode("shift_jis")).encode("utf-8")
     assert_equal "23字下げ",
-                 @parser.convert_japanese_number("二十三字下げ".encode("shift_jis")).encode("utf-8")
+                 Aozora2Html::Utils.convert_japanese_number("二十三字下げ".encode("shift_jis")).encode("utf-8")
     assert_equal "2字下げ",
-                 @parser.convert_japanese_number("２字下げ".encode("shift_jis")).encode("utf-8")
+                 Aozora2Html::Utils.convert_japanese_number("２字下げ".encode("shift_jis")).encode("utf-8")
 
   end
 

--- a/test/test_aozora2html.rb
+++ b/test/test_aozora2html.rb
@@ -264,6 +264,7 @@ class Aozora2HtmlTest < Test::Unit::TestCase
     rescue Aozora2Html::Error => e
       message = e.message.encode("utf-8")
     ensure
+      $stdout = STDOUT
       assert_equal "エラー(0行目):縦中横中に改行されました。改行をまたぐ要素にはブロック表記を用いてください. \r\n処理を停止します", message
     end
   end
@@ -283,6 +284,7 @@ class Aozora2HtmlTest < Test::Unit::TestCase
     rescue Aozora2Html::Error => e
       message = e.message.encode("utf-8")
     ensure
+      $stdout = STDOUT
       assert_equal "エラー(0行目):字下げ中に本文が終了しました. \r\n処理を停止します", message
     end
   end
@@ -299,6 +301,7 @@ class Aozora2HtmlTest < Test::Unit::TestCase
     rescue Aozora2Html::Error => e
       message = e.message.encode("utf-8")
     ensure
+      $stdout = STDOUT
       assert_equal "エラー(0行目):太字を閉じようとしましたが、太字中ではありません. \r\n処理を停止します", message
     end
   end
@@ -321,6 +324,7 @@ class Aozora2HtmlTest < Test::Unit::TestCase
     rescue Aozora2Html::Error => e
       message = e.message.encode("utf-8")
     ensure
+      $stdout = STDOUT
       assert_equal "エラー(0行目):太字を終了しようとしましたが、傍線中です. \r\n処理を停止します", message
     end
   end

--- a/test/test_font_size_tag.rb
+++ b/test/test_font_size_tag.rb
@@ -1,3 +1,4 @@
+# -*- coding:utf-8 -*-
 require 'test_helper'
 require 'aozora2html'
 

--- a/test/test_font_size_tag.rb
+++ b/test/test_font_size_tag.rb
@@ -29,6 +29,12 @@ class FontSizeTagTest < Test::Unit::TestCase
     assert_equal "<div class=\"sho3\" style=\"font-size: xx-small;\">", tag.to_s.encode("utf-8")
   end
 
+  def test_to_s0
+    assert_raise(Aozora2Html::Error.new("文字サイズの指定が不正です".to_sjis)) do
+      _tag = Aozora2Html::Tag::FontSize.new(@parser,0,:sho)
+    end
+  end
+
   def teardown
   end
 end

--- a/test/test_ruby_parse.rb
+++ b/test/test_ruby_parse.rb
@@ -97,6 +97,13 @@ class RubyParseTest < Test::Unit::TestCase
     assert_equal expected, parsed
   end
 
+  def test_parse_ruby12
+    src = "大空文庫《あおぞらぶんこ》［＃「大空文庫」に「ママ」の注記］\r\n"
+    assert_raise(Aozora2Html::Error.new("同じ箇所に2つのルビはつけられません".encode("shift_jis"))) do
+      parsed = parse_text(src)
+    end
+  end
+
   def parse_text(input_text)
     input = StringIO.new(input_text.encode("shift_jis"))
     output = StringIO.new

--- a/test/test_ruby_parse.rb
+++ b/test/test_ruby_parse.rb
@@ -100,7 +100,7 @@ class RubyParseTest < Test::Unit::TestCase
   def test_parse_ruby12
     src = "大空文庫《あおぞらぶんこ》［＃「大空文庫」に「ママ」の注記］\r\n"
     assert_raise(Aozora2Html::Error.new("同じ箇所に2つのルビはつけられません".encode("shift_jis"))) do
-      parsed = parse_text(src)
+      _parsed = parse_text(src)
     end
   end
 


### PR DESCRIPTION
ソースコードの文字コードを全部UTF-8にするものです。

処理対象のテキストファイル自体は極力Shift_JISのままにしています。
コード内の文字列と正規表現リテラルは、`String#to_sjis`という`.encode("shift_jis")`のエイリアスみたいなものを導入して、Shift_JISに変換しています。