### PR TITLE
make lazy loading zip library

### DIFF
--- a/bin/aozora2html
+++ b/bin/aozora2html
@@ -61,6 +61,7 @@ Dir.mktmpdir do |dir|
   end
 
   if File.extname(src_file) == ".zip"
+    require "aozora2html/zip"
     tmpfile = File.join(dir, "aozora.txt")
     Aozora2Html::Zip.unzip(src_file, tmpfile)
     Aozora2Html.new(tmpfile, dest_file).process

--- a/lib/t2hs.rb
+++ b/lib/t2hs.rb
@@ -11,7 +11,6 @@ require "aozora2html/style_stack"
 require "aozora2html/header"
 require "aozora2html/ruby_buffer"
 require "aozora2html/yaml_loader"
-require "aozora2html/zip"
 require "aozora2html/utils"
 
 $gaiji_dir = "../../../gaiji/"


### PR DESCRIPTION
現状は`aozora2html/zip`とRubyZipライブラリを必ずloadするようにしていますが、元ファイルがzipファイル以外の場合は特に必要ないため、必要なときのみloadするようにします。