### PR TITLE
[ fix, change ] RuboCop configulation and apply some rules (and explicitly state minimum Ruby version)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 #*#
 *.bak
 pkg
+/.ruby-version

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.bak
 pkg
 /.ruby-version
+/Gemfile.lock

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,13 +1,17 @@
+require: rubocop-performance
+
 inherit_gem:
   meowcop:
     - config/rubocop.yml
 
 AllCops:
-  TargetRubyVersion: 2.1
+  # Rubocop's supporting Ruby versions is as follows:
+  # > Supported versions: 2.5, 2.6, 2.7, 3.0, 3.1
+  TargetRubyVersion: 2.5
 
 # EnforcedStyle: with_first_parameter => 0 offense
 # EnforcedStyle: with_fixed_indentation => 17 offenses
-Layout/AlignParameters:
+Layout/ParameterAlignment:
   EnforcedStyle: with_first_parameter
   Enabled: true
 
@@ -117,7 +121,7 @@ Layout/SpaceAroundOperators:
 Layout/SpaceInsideBlockBraces:
   Enabled: false
 
-Style/UnneededPercentQ:
+Style/RedundantPercentQ:
   Enabled: false
 
 Style/PercentQLiterals:
@@ -168,7 +172,7 @@ Style/NumericPredicate:
 Style/ZeroLengthPredicate:
   Enabled: false
 
-Layout/TrailingBlankLines:
+Layout/TrailingEmptyLines:
   Enabled: false
 
 Metrics/AbcSize:
@@ -221,7 +225,7 @@ Layout/SpaceBeforeBlockBraces:
   Enabled: false
 
 ### あとで直す
-Lint/StringConversionInInterpolation:
+Lint/RedundantStringCoercion:
   Enabled: false
 Style/ClassAndModuleChildren:
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,6 +11,10 @@ AllCops:
 
   NewCops: enable
 
+Gemspec/RequiredRubyVersion:
+  # RuboCop v1.19.0 does not support Ruby v2.4, but it will still work.
+  Enabled: false
+
 # EnforcedStyle: with_first_parameter => 0 offense
 # EnforcedStyle: with_fixed_indentation => 17 offenses
 Layout/ParameterAlignment:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -81,7 +81,7 @@ Style/MethodDefParentheses:
 
 # EnforcedStyle: snake_case => 0 offense
 # EnforcedStyle: camelCase => 268 offenses
-Style/MethodName:
+Naming/MethodName:
   EnforcedStyle: snake_case
   Enabled: true
 
@@ -100,14 +100,14 @@ Style/SignalException:
 
 # EnforcedStyle: snake_case => 0 offense
 # EnforcedStyle: camelCase => 126 offenses
-Style/VariableName:
+Naming/VariableName:
   EnforcedStyle: snake_case
   Enabled: true
 
 # EnforcedStyle: snake_case => 11 offenses
 # EnforcedStyle: normalcase => 0 offense
 # EnforcedStyle: non_integer => 11 offenses
-Style/VariableNumber:
+Naming/VariableNumber:
   EnforcedStyle: normalcase
   Enabled: true
 
@@ -197,7 +197,7 @@ Metrics/CyclomaticComplexity:
   Enabled: true
   Max: 100
 
-Metrics/LineLength:
+Layout/LineLength:
   Enabled: true
   Max: 500
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -33,12 +33,6 @@ Layout/SpaceAroundBlockParameters:
   EnforcedStyleInsidePipes: no_space
   Enabled: true
 
-# EnforcedStyle: space => 42 offenses
-# EnforcedStyle: no_space => 4 offenses
-Layout/SpaceBeforeBlockBraces:
-  EnforcedStyle: no_space
-  Enabled: true
-
 # EnforcedStyle: space => 98 offenses
 # EnforcedStyle: no_space => 0 offense
 Layout/SpaceInsideStringInterpolation:
@@ -51,23 +45,10 @@ Style/BarePercentLiterals:
   EnforcedStyle: percent_q
   Enabled: true
 
-# EnforcedStyle: nested => 2 offenses
-# EnforcedStyle: compact => 81 offenses
-Style/ClassAndModuleChildren:
-  EnforcedStyle: nested
-  Enabled: true
-
 # EnforcedStyle: compact => 24 offenses
 # EnforcedStyle: expanded => 0 offense
 Style/EmptyMethod:
   EnforcedStyle: expanded
-  Enabled: true
-
-# EnforcedStyle: when_needed => 10 offenses
-# EnforcedStyle: always => 57 offenses
-# EnforcedStyle: never => 32 offenses
-Style/Encoding:
-  EnforcedStyle: when_needed
   Enabled: true
 
 # EnforcedStyle: for => 13 offenses

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,6 +9,8 @@ AllCops:
   # > Supported versions: 2.5, 2.6, 2.7, 3.0, 3.1
   TargetRubyVersion: 2.5
 
+  NewCops: enable
+
 # EnforcedStyle: with_first_parameter => 0 offense
 # EnforcedStyle: with_fixed_indentation => 17 offenses
 Layout/ParameterAlignment:

--- a/aozora2html.gemspec
+++ b/aozora2html.gemspec
@@ -30,4 +30,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 12.0"
   spec.add_development_dependency "test-unit"
   spec.add_development_dependency "test-unit-rr"
+  spec.add_development_dependency "rubocop"
+  spec.add_development_dependency "meowcop"
 end

--- a/aozora2html.gemspec
+++ b/aozora2html.gemspec
@@ -21,11 +21,10 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  if RUBY_VERSION < "2.4.0"
-    spec.add_dependency "rubyzip", "~> 1.3"
-  else
-    spec.add_dependency "rubyzip", "~> 2.0"
-  end
+  # Refer to current CI status at https://github.com/aozorahack/aozora2html/pull/39
+  spec.required_ruby_version = '>= 2.4', '< 3'
+
+  spec.add_dependency "rubyzip", "~> 2.0"
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake", "~> 12.0"

--- a/aozora2html.gemspec
+++ b/aozora2html.gemspec
@@ -26,10 +26,14 @@ Gem::Specification.new do |spec|
   else
     spec.add_dependency "rubyzip", "~> 2.0"
   end
+
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake", "~> 12.0"
   spec.add_development_dependency "test-unit"
   spec.add_development_dependency "test-unit-rr"
+
+  # RuboCop related development dependencies
   spec.add_development_dependency "rubocop"
   spec.add_development_dependency "meowcop"
+  spec.add_development_dependency "rubocop-performance"
 end

--- a/bin/aozora2html
+++ b/bin/aozora2html
@@ -41,7 +41,7 @@ Dir.mktmpdir do |dir|
   if dest_file.nil?
     dest_file = File.join(dir, "output.html")
   end
-  if src_file =~ /\Ahttps?:/
+  if /\Ahttps?:/.match?(src_file)
     down_file = File.join(dir, File.basename(src_file))
     begin
       File.write(down_file, URI.parse(src_file).read)

--- a/lib/aozora2html.rb
+++ b/lib/aozora2html.rb
@@ -1,6 +1,2 @@
 require "aozora2html/version"
 require 't2hs'
-
-## already defined in t2hs.rb
-class Aozora2Html
-end

--- a/lib/aozora2html/accent_parser.rb
+++ b/lib/aozora2html/accent_parser.rb
@@ -5,7 +5,7 @@ class Aozora2Html
   # accent特殊文字を生かすための再帰呼び出し
   class AccentParser < Aozora2Html
 
-    def initialize(input, endchar, chuuki, image)
+    def initialize(input, endchar, chuuki, image) # rubocop:todo Lint/MissingSuper
       if not(input.is_a?(Jstream))
         raise ArgumentError, "tag_parser must supply Jstream as input"
       end

--- a/lib/aozora2html/error.rb
+++ b/lib/aozora2html/error.rb
@@ -6,6 +6,7 @@ class Aozora2Html
 
     def initialize(msg)
       @message = msg
+      super
     end
 
     def message(line = 0)

--- a/lib/aozora2html/tag/multiline_caption.rb
+++ b/lib/aozora2html/tag/multiline_caption.rb
@@ -3,10 +3,6 @@ class Aozora2Html
     class MultilineCaption < Aozora2Html::Tag
       include Aozora2Html::Tag::Block, Aozora2Html::Tag::Multiline
 
-      def initialize(parser)
-        super
-      end
-
       def to_s
         "<div class=\"caption\">"
       end

--- a/lib/aozora2html/tag/multiline_yokogumi.rb
+++ b/lib/aozora2html/tag/multiline_yokogumi.rb
@@ -3,10 +3,6 @@ class Aozora2Html
     class MultilineYokogumi < Aozora2Html::Tag
       include Aozora2Html::Tag::Block, Aozora2Html::Tag::Multiline
 
-      def initialize(parser)
-        super
-      end
-
       def to_s
         "<div class=\"yokogumi\">"
       end

--- a/lib/aozora2html/tag/reference_mentioned.rb
+++ b/lib/aozora2html/tag/reference_mentioned.rb
@@ -6,7 +6,7 @@ class Aozora2Html
       include Aozora2Html::Tag::Inline
       attr_accessor :target
 
-      def initialize(*args)
+      def initialize(*args) # rubocop:todo Lint/MissingSuper
         if defined?(@target) && block_element?(@target)
           syntax_error
         end
@@ -21,7 +21,7 @@ class Aozora2Html
           end
           nil
         elsif elt.is_a?(String)
-          elt.match(/<div/)
+          elt.include?('<div')
         else
           elt.is_a?(Aozora2Html::Tag::Block)
         end

--- a/lib/aozora2html/tag_parser.rb
+++ b/lib/aozora2html/tag_parser.rb
@@ -2,7 +2,7 @@
 require 'aozora2html/ruby_buffer'
 class Aozora2Html
   class TagParser < Aozora2Html
-    def initialize(input, endchar, chuuki, image)
+    def initialize(input, endchar, chuuki, image) # rubocop:todo Lint/MissingSuper
       if not(input.is_a?(Jstream))
         raise ArgumentError, "tag_parser must supply Jstream as input"
       end

--- a/lib/extensions.rb
+++ b/lib/extensions.rb
@@ -21,7 +21,7 @@ class String
       :hankaku
     elsif ch.match(Regexp.new("[亜-熙々※仝〆〇ヶ]".encode("shift_jis")))
       :kanji
-    elsif ch.match(/[\.\;\"\?\!\)]/)
+    elsif ch.match?(/[\.\;\"\?\!\)]/)
       :hankaku_terminate
     else
       :else

--- a/lib/t2hs.rb
+++ b/lib/t2hs.rb
@@ -378,7 +378,7 @@ class Aozora2Html
 
   def parse_chuuki
     string = read_line
-    if string.match(/^\-+$/)
+    if string.match?(/^\-+$/)
       case @section
       when :chuuki
         @section = :chuuki_in
@@ -802,7 +802,7 @@ class Aozora2Html
       apply_warichu(command)
     elsif command.match(JISAGE_COMMAND)
       apply_jisage(command)
-    elsif command.match(/fig(\d)+_(\d)+\.png/)
+    elsif command.match?(/fig(\d)+_(\d)+\.png/)
       exec_img_command(command,raw)
     # avoid to try complex ruby -- escape to notes
     elsif command.match(PAT_REST_NOTES)
@@ -812,7 +812,7 @@ class Aozora2Html
       nil
     elsif command.match(PAT_REF)
       exec_frontref_command(command)
-    elsif command.match(/1-7-8[2345]/)
+    elsif command.match?(/1-7-8[2345]/)
       apply_dakuten_katakana(command)
     elsif command.match(PAT_KAERITEN)
       Aozora2Html::Tag::Kaeriten.new(self, command)
@@ -850,7 +850,7 @@ class Aozora2Html
   end
 
   def jisage_width(command)
-    Utils.convert_japanese_number(command).match(/(\d*)(?:#{JISAGE_COMMAND})/)[1]
+    Utils.convert_japanese_number(command).match(/(\d*)(?:#{JISAGE_COMMAND})/o)[1]
   end
 
   def apply_jisage(command)
@@ -929,11 +929,11 @@ class Aozora2Html
     end
 
     case size
-    when /#{SIZE_SMALL}/
+    when /#{SIZE_SMALL}/o
       inc = 1
-    when /#{SIZE_MIDDLE}/
+    when /#{SIZE_MIDDLE}/o
       inc = 10
-    when /#{SIZE_LARGE}/
+    when /#{SIZE_LARGE}/o
       inc = 100
     else
       raise Aozora2Html::Error, I18n.t(:undefined_header)
@@ -1103,11 +1103,11 @@ class Aozora2Html
 
   def exec_block_start_command(command)
     original_command = command.dup
-    command.sub!(/^#{OPEN_MARK}/, "")
+    command.sub!(/^#{OPEN_MARK}/o, "")
     match = ""
     if command.match(INDENT_TYPE[:jisage])
       push_block_tag(apply_jisage(command),match)
-    elsif command.match(/(#{INDENT_TYPE[:chitsuki]}|#{JIAGE_COMMAND})$/)
+    elsif command.match?(/(#{INDENT_TYPE[:chitsuki]}|#{JIAGE_COMMAND})$/)
       push_block_tag(apply_chitsuki(command,true),match)
     end
 
@@ -1197,7 +1197,7 @@ class Aozora2Html
 
   def exec_block_end_command(command)
     original_command = command.dup
-    command.sub!(/^#{CLOSE_MARK}/, "")
+    command.sub!(/^#{CLOSE_MARK}/o, "")
     match = false
     mode = detect_command_mode(command)
     if mode
@@ -1543,7 +1543,7 @@ class Aozora2Html
     @buffer = []
     string.gsub!("info@aozora.gr.jp",'<a href="mailto: info@aozora.gr.jp">info@aozora.gr.jp</a>')
     string.gsub!("青空文庫（http://www.aozora.gr.jp/）".to_sjis){"<a href=\"http://www.aozora.gr.jp/\">#{$&}</a>"}
-    if string.match(/(<br \/>$|<\/p>$|<\/h\d>$|<div.*>$|<\/div>$|^<[^>]*>$)/)
+    if string.match?(/(<br \/>$|<\/p>$|<\/h\d>$|<div.*>$|<\/div>$|^<[^>]*>$)/)
       @out.print string, "\r\n"
     else
       @out.print string, "<br />\r\n"

--- a/lib/t2hs.rb
+++ b/lib/t2hs.rb
@@ -822,7 +822,7 @@ class Aozora2Html
       apply_chitsuki(command)
     elsif exec_inline_start_command(command)
       nil
-    else
+    else # rubocop:todo Lint/DuplicateBranch
       apply_rest_notes(command)
     end
   end
@@ -871,7 +871,7 @@ class Aozora2Html
       @noprint = false
       @indent_stack.push(:jisage)
       Aozora2Html::Tag::MultilineJisage.new(self, jisage_width(command))
-    else
+    else # rubocop:todo Lint/DuplicateBranch
       @buffer.unshift(Aozora2Html::Tag::OnelineJisage.new(self, jisage_width(command)))
       nil
     end

--- a/test/test_aozora2html.rb
+++ b/test/test_aozora2html.rb
@@ -55,7 +55,7 @@ class Aozora2HtmlTest < Test::Unit::TestCase
     end
   end
 
-  def test_line_number_2
+  def test_line_number2
     input = StringIO.new("a\r\nb\r\nc\r\n")
     output = StringIO.new
     parser = Aozora2Html.new(input, output)


### PR DESCRIPTION
* Fix RuboCop configulation
  * Add RuboCop and related gems as development dependencies to gemspec file
  * Fix rule names
* Apply some RuboCop rules
* Update Ruby version from v2.1 to v2.5 on `.rubocop.yml`
* **Explicitly state that required Ruby version is v2.4 <= v < v3.0 on gemspec file.**
  * I don't want to include this change in this pull request at least, but I think it's essential in terms of quality assurance by RuboCop.
  * If this is not desirable, we need to find out the minimum version of Ruby that will work instead.
  * Maybe the [readme](https://github.com/aozorahack/aozora2html#%E5%8B%95%E4%BD%9C%E7%92%B0%E5%A2%83) needs to be fixed too.
