### PR TITLE
[ fix, change ] puts behavior for Ruby v3.0.x

### DIFF
--- a/lib/extensions.rb
+++ b/lib/extensions.rb
@@ -33,3 +33,12 @@ class String
   end
 end
 
+module Kernel
+  alias original_kernel_puts puts
+
+  def puts(*args)
+    original_kernel_puts(args)
+  rescue Encoding::CompatibilityError
+    original_kernel_puts(args.map { |arg| arg.force_encoding('utf-8') })
+  end
+end

--- a/test/test_i18n.rb
+++ b/test/test_i18n.rb
@@ -1,0 +1,23 @@
+# encoding: utf-8
+require 'test_helper'
+require 'aozora2html'
+
+class I18nTest < Test::Unit::TestCase
+  def test_t
+      assert_equal "警告(123行目):JIS外字「①」が使われています",
+                   Aozora2Html::I18n.t(:warn_jis_gaiji,
+                                       123,
+                                       "①".encode("cp932").force_encoding("shift_jis"))
+                     .force_encoding("cp932").encode("utf-8")
+  end
+
+  def test_ruby_puts_behavior
+    $stdout = StringIO.new
+    begin
+      puts "①".encode("cp932").force_encoding("shift_jis")
+      assert_equal "①\n", $stdout.string.force_encoding("cp932").encode("utf-8")
+    ensure
+      $stdout = STDOUT
+    end
+  end
+end


### PR DESCRIPTION
* Ruby v2.7.x 以前では通っていたテストも Ruby v3.x.x から `Encoding::CompatibilityError` により失敗する箇所があることを確認しました。
  * Ruby v3 から `Kernel#puts` （もしくは `IO#write` ）に変化があったようです（詳細は未調査です）。
* この変更は `puts` に変更を加えることでこの問題を回避しようとしています。
  * この変更の仕方ではなく、別のメソッドを定義してそれを使うことで回避した方が安全かもしれません。
* `lib/i18n.rb` へのテストを追加しました。
* 関連： #39 
