### PR TITLE
[ update ] .gitignore e.g. for .ruby-version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,9 @@
-*~
-#*#
+*#
 *.bak
-pkg
+*~
+/*.gem
+/.ruby-version
+/.yardoc/
+/Gemfile.lock
+/doc/
+/pkg/


### PR DESCRIPTION
開発時に以下のファイルが生成されますが、これをGitの管理に含めないようにします。

* `/*.gem` : `$ gem build` により生成されるバイナリファイル
* `/.ruby-version` : バージョンを切り換えるため `$ rbenv local {{Ruby version number}}` としたときに生成されるRubyのバージョンを指定するファイル
* `/.yardoc`, `/doc` : YARD（またはRDoc）によるドキュメント生成を行った際に生成されるディレクトリ
* `/Gemfile.lock` : `$ bundle install` の際に生成されるバージョンを固定するファイル
