### PR TITLE
Set the current package to v2.0.0

### DIFF
--- a/lib/aozora2html/version.rb
+++ b/lib/aozora2html/version.rb
@@ -1,3 +1,3 @@
 class Aozora2Html
-  VERSION = "0.9.1"
+  VERSION = "2.0.0"
 end


### PR DESCRIPTION
https://github.com/aozorahack/aozora2html/issues/44#issuecomment-986055000  にも書きましたが、現状のパッケージはRuby 3.0以降に追従できていないこと、開発ツールの互換性維持が難しいこともあり、

* 現状のパッケージ (Ruby >= 2.0) を2.0.xにする
* 3.0でビルドできるようにしたパッケージを3.xにする

ということにして、古いRubyで動かしたい人はv2.xを選択してもらえれば使えるようにしつつ、最近のRubyを使っている人は最新版が利用できる、という状況を目指します。

そのため、まずは現在のライブラリを2.0.0としてリリースしておきます。

なお、1.0にしないのは「Ruby 2.xだとv2.xを使う、とした方が分かりやすいかも？」という理由によるもので、v1.xは欠番になります。