### PR TITLE
Do not execute `t2hs.rb` directly; use `bin/aozora2html`

### DIFF
--- a/lib/t2hs.rb
+++ b/lib/t2hs.rb
@@ -1594,8 +1594,3 @@ class Aozora2Html
     @out.print "</div>\r\n"
   end
 end
-
-if $0 == __FILE__
-  # TODO: 引数チェックとか
-  Aozora2Html.new($*[0], $*[1]).process
-end


### PR DESCRIPTION
t2hs.rbから直接実行できないようにします。