### PR TITLE
refactor: move illegal_char_check to Aozora2Html::Utils

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -100,7 +100,7 @@ Metrics/MethodLength:
 
 Metrics/ModuleLength:
   Enabled: true
-  Max: 100
+  Max: 200
 
 Metrics/ParameterLists:
   Enabled: true

--- a/lib/aozora2html/accent_parser.rb
+++ b/lib/aozora2html/accent_parser.rb
@@ -82,7 +82,7 @@ class Aozora2Html
         @ruby_buf.dump_into(@buffer)
         @ruby_buf.protected = true
       elsif (first != '') && !first.nil?
-        illegal_char_check(first, line_number)
+        Utils.illegal_char_check(first, line_number)
         push_chars(first)
       end
     end

--- a/lib/aozora2html/utils.rb
+++ b/lib/aozora2html/utils.rb
@@ -83,5 +83,68 @@ class Aozora2Html
       tmp
     end
     module_function :convert_japanese_number
+
+    # 使うべきではない文字があるかチェックする
+    #
+    # 警告を出力するだけで結果には影響を与えない。警告する文字は以下:
+    #
+    # * 1バイト文字
+    # * `＃`ではなく`♯`
+    # * JIS(JIS X 0208)外字
+    #
+    # @return [void]
+    #
+    def illegal_char_check(char, line)
+      return unless char.is_a?(String)
+
+      code = char.unpack1('H*')
+      if (code == '21') ||
+         (code == '23') ||
+         ((code >= 'a1') && (code <= 'a5')) ||
+         ((code >= '28') && (code <= '29')) ||
+         (code == '5b') ||
+         (code == '5d') ||
+         (code == '3d') ||
+         (code == '3f') ||
+         (code == '2b') ||
+         ((code >= '7b') && (code <= '7d'))
+        puts I18n.t(:warn_onebyte, line, char)
+      end
+
+      if code == '81f2'
+        puts I18n.t(:warn_chuki, line, char)
+      end
+
+      if ((code >= '81ad') && (code <= '81b7')) ||
+         ((code >= '81c0') && (code <= '81c7')) ||
+         ((code >= '81cf') && (code <= '81d9')) ||
+         ((code >= '81e9') && (code <= '81ef')) ||
+         ((code >= '81f8') && (code <= '81fb')) ||
+         ((code >= '8240') && (code <= '824e')) ||
+         ((code >= '8259') && (code <= '825f')) ||
+         ((code >= '827a') && (code <= '8280')) ||
+         ((code >= '829b') && (code <= '829e')) ||
+         ((code >= '82f2') && (code <= '82fc')) ||
+         ((code >= '8397') && (code <= '839e')) ||
+         ((code >= '83b7') && (code <= '83be')) ||
+         ((code >= '83d7') && (code <= '83fc')) ||
+         ((code >= '8461') && (code <= '846f')) ||
+         ((code >= '8492') && (code <= '849e')) ||
+         ((code >= '84bf') && (code <= '84fc')) ||
+         ((code >= '8540') && (code <= '85fc')) ||
+         ((code >= '8640') && (code <= '86fc')) ||
+         ((code >= '8740') && (code <= '87fc')) ||
+         ((code >= '8840') && (code <= '889e')) ||
+         ((code >= '9873') && (code <= '989e')) ||
+         ((code >= 'eaa5') && (code <= 'eafc')) ||
+         ((code >= 'eb40') && (code <= 'ebfc')) ||
+         ((code >= 'ec40') && (code <= 'ecfc')) ||
+         ((code >= 'ed40') && (code <= 'edfc')) ||
+         ((code >= 'ee40') && (code <= 'eefc')) ||
+         ((code >= 'ef40') && (code <= 'effc'))
+        puts I18n.t(:warn_jis_gaiji, line, char)
+      end
+    end
+    module_function :illegal_char_check
   end
 end

--- a/lib/t2hs.rb
+++ b/lib/t2hs.rb
@@ -378,68 +378,6 @@ class Aozora2Html
     end
   end
 
-  # 使うべきではない文字があるかチェックする
-  #
-  # 警告を出力するだけで結果には影響を与えない。警告する文字は以下:
-  #
-  # * 1バイト文字
-  # * `＃`ではなく`♯`
-  # * JIS(JIS X 0208)外字
-  #
-  # @return [void]
-  #
-  def illegal_char_check(char, line)
-    return unless char.is_a?(String)
-
-    code = char.unpack1('H*')
-    if (code == '21') ||
-       (code == '23') ||
-       ((code >= 'a1') && (code <= 'a5')) ||
-       ((code >= '28') && (code <= '29')) ||
-       (code == '5b') ||
-       (code == '5d') ||
-       (code == '3d') ||
-       (code == '3f') ||
-       (code == '2b') ||
-       ((code >= '7b') && (code <= '7d'))
-      puts I18n.t(:warn_onebyte, line, char)
-    end
-
-    if code == '81f2'
-      puts I18n.t(:warn_chuki, line, char)
-    end
-
-    if ((code >= '81ad') && (code <= '81b7')) ||
-       ((code >= '81c0') && (code <= '81c7')) ||
-       ((code >= '81cf') && (code <= '81d9')) ||
-       ((code >= '81e9') && (code <= '81ef')) ||
-       ((code >= '81f8') && (code <= '81fb')) ||
-       ((code >= '8240') && (code <= '824e')) ||
-       ((code >= '8259') && (code <= '825f')) ||
-       ((code >= '827a') && (code <= '8280')) ||
-       ((code >= '829b') && (code <= '829e')) ||
-       ((code >= '82f2') && (code <= '82fc')) ||
-       ((code >= '8397') && (code <= '839e')) ||
-       ((code >= '83b7') && (code <= '83be')) ||
-       ((code >= '83d7') && (code <= '83fc')) ||
-       ((code >= '8461') && (code <= '846f')) ||
-       ((code >= '8492') && (code <= '849e')) ||
-       ((code >= '84bf') && (code <= '84fc')) ||
-       ((code >= '8540') && (code <= '85fc')) ||
-       ((code >= '8640') && (code <= '86fc')) ||
-       ((code >= '8740') && (code <= '87fc')) ||
-       ((code >= '8840') && (code <= '889e')) ||
-       ((code >= '9873') && (code <= '989e')) ||
-       ((code >= 'eaa5') && (code <= 'eafc')) ||
-       ((code >= 'eb40') && (code <= 'ebfc')) ||
-       ((code >= 'ec40') && (code <= 'ecfc')) ||
-       ((code >= 'ed40') && (code <= 'edfc')) ||
-       ((code >= 'ee40') && (code <= 'eefc')) ||
-       ((code >= 'ef40') && (code <= 'effc'))
-      puts I18n.t(:warn_jis_gaiji, line, char)
-    end
-  end
-
   # 本体解析部
   #
   # 1文字ずつ読み込み、dispatchして@buffer,@ruby_bufへしまう
@@ -480,7 +418,7 @@ class Aozora2Html
       # noop
     else
       if check
-        illegal_char_check(char, line_number)
+        Utils.illegal_char_check(char, line_number)
       end
       push_chars(char)
     end
@@ -1523,7 +1461,7 @@ class Aozora2Html
       # noop
     else
       if check
-        illegal_char_check(char, line_number)
+        Utils.illegal_char_check(char, line_number)
       end
       push_chars(char)
     end

--- a/test/test_aozora2html.rb
+++ b/test/test_aozora2html.rb
@@ -117,13 +117,10 @@ class Aozora2HtmlTest < Test::Unit::TestCase
   end
 
   def test_illegal_char_check
-    input = StringIO.new("abc\r\n")
-    output = StringIO.new
-    parser = Aozora2Html.new(input, output)
     out = StringIO.new
     $stdout = out
     begin
-      parser.illegal_char_check('#', 123)
+      Aozora2Html::Utils.illegal_char_check('#', 123)
       outstr = out.string
       assert_equal "警告(123行目):1バイトの「#」が使われています\n", outstr.encode('utf-8')
     ensure
@@ -132,13 +129,10 @@ class Aozora2HtmlTest < Test::Unit::TestCase
   end
 
   def test_illegal_char_check_sharp
-    input = StringIO.new("abc\r\n")
-    output = StringIO.new
-    parser = Aozora2Html.new(input, output)
     out = StringIO.new
     $stdout = out
     begin
-      parser.illegal_char_check('♯'.encode('shift_jis'), 123)
+      Aozora2Html::Utils.illegal_char_check('♯'.encode('shift_jis'), 123)
       outstr = out.string
       assert_equal "警告(123行目):注記記号の誤用の可能性がある、「♯」が使われています\n", outstr.encode('utf-8')
     ensure
@@ -147,13 +141,10 @@ class Aozora2HtmlTest < Test::Unit::TestCase
   end
 
   def test_illegal_char_check_notjis
-    input = StringIO.new("abc\r\n")
-    output = StringIO.new
-    parser = Aozora2Html.new(input, output)
     out = StringIO.new
     $stdout = out
     begin
-      parser.illegal_char_check('①'.encode('cp932').force_encoding('shift_jis'), 123)
+      Aozora2Html::Utils.illegal_char_check('①'.encode('cp932').force_encoding('shift_jis'), 123)
       outstr = out.string
       assert_equal "警告(123行目):JIS外字「①」が使われています\n", outstr.force_encoding('cp932').encode('utf-8')
     ensure
@@ -162,14 +153,11 @@ class Aozora2HtmlTest < Test::Unit::TestCase
   end
 
   def test_illegal_char_check_ok
-    input = StringIO.new("abc\r\n")
-    output = StringIO.new
-    parser = Aozora2Html.new(input, output)
     out = StringIO.new
     $stdout = out
     begin
-      parser.illegal_char_check('あ'.encode('shift_jis'), 123)
-      outstr = output.string
+      Aozora2Html::Utils.illegal_char_check('あ'.encode('shift_jis'), 123)
+      outstr = out.string
       assert_equal '', outstr
     ensure
       $stdout = STDOUT


### PR DESCRIPTION
`illegal_char_check`は本質的にparserと関係がない、単なる文字チェッカなのでUtilsに移動させます。