### PR TITLE
refactor read_line; ignore `@buffer`

### DIFF
--- a/lib/t2hs.rb
+++ b/lib/t2hs.rb
@@ -203,13 +203,10 @@ class Aozora2Html
 
   # 1行読み込み
   #
-  # 合わせて@bufferもクリアする
   # @return [String] 読み込んだ文字列を返す
   #
   def read_line
-    tmp = read_to("\r\n")
-    @buffer = []
-    tmp
+    read_to("\r\n")
   end
 
   # parseする


### PR DESCRIPTION
`read_line`は`parse_header`と`parse_chuuki`でしか使われておらず、どちらも`@buffer`は操作していないため、`@buffer`の初期化を削除します。

全体的に`@buffer`と`@ruby_buf`の二重管理が複雑にしているところがありそうなので、もう少し整理したいです（おそらく高速化・効率化のためかと思いますが、現代ではもっと富豪にしても支障ないはず）。