### PR TITLE
refactor Jstream; remove `@buffer`

### DIFF
--- a/lib/jstream.rb
+++ b/lib/jstream.rb
@@ -77,7 +77,7 @@ class Jstream
     char = nil
 
     begin
-      pos.times { @file.getc }
+      pos.times { read_char }
 
       char = @file.getc
       if char == CR

--- a/lib/jstream.rb
+++ b/lib/jstream.rb
@@ -11,19 +11,29 @@ require_relative 'aozora2html/i18n'
 # when found line terminator except CR+LF, exit.
 #
 class Jstream
-  attr_accessor :line
+  CR = "\r"
+  LF = "\n"
+  CRLF = CR + LF
 
+  # 初期化と同時に、いったん最初の行をscanして、改行コードがCR+LFかどうか調べる。
+  # CR+LFでない場合はエラーメッセージを出力してexitする(!)
+  #
+  # TODO: 将来的にはさすがにexitまではしないよう、仕様を変更する?
   def initialize(file_io)
     @line = 0
-    @entry = false
+    @current_char = nil
     @file = file_io
+
     begin
-      store_to_buffer
+      tmp = @file.readline.chomp!("\r\n")
+      raise Aozora2Html::Error, Aozora2Html::I18n.t(:use_crlf) unless tmp
     rescue Aozora2Html::Error => e
       puts e.message(1)
       if e.is_a?(Aozora2Html::Error)
         exit(2)
       end
+    ensure
+      @file.rewind
     end
   end
 
@@ -31,39 +41,74 @@ class Jstream
     "#<jcode-stream input #{@file.inspect}>"
   end
 
+  # 1文字読み込んで返す
+  #
+  # 行末の場合は(1文字ではなく)CR+LFを返す
+  # EOFまで到達すると :eof というシンボルを返す
+  #
+  # TODO: EOFの場合はnilを返すように変更する?
   def read_char
-    found = @buffer.shift
-    if @entry
+    char = @file.getc
+
+    if char == CR
+      char2 = @file.getc
+      if char2 != LF
+        raise Aozora2Html::Error, Aozora2Html::I18n.t(:use_crlf)
+      end
+
       @line += 1
-      @entry = false
-    end
-    if found
-      return found
+      @current_char = char + char2
+    elsif char.nil?
+      @current_char = :eof
+    else
+      @current_char = char
     end
 
-    begin
-      store_to_buffer
-    rescue EOFError
-      @buffer = [:eof]
-    end
-    "\r\n"
+    @current_char
   end
 
+  # pos個分の文字を先読みし、最後の文字を返す
+  #
+  # ファイルディスクリプタは移動しない（実行前の位置まで戻す）
+  # 行末の場合は(1文字ではなく)CR+LFを返す
+  # 行末の先に進んだ場合の挙動は未定義になる
   def peek_char(pos)
-    @buffer[pos] || "\r\n"
+    original_pos = @file.pos
+    char = nil
+
+    begin
+      pos.times { @file.getc }
+
+      char = @file.getc
+      if char == CR
+        char2 = @file.getc
+        if char2 != LF
+          raise Aozora2Html::Error, Aozora2Html::I18n.t(:use_crlf)
+        end
+
+        char += char2
+      end
+    ensure
+      @file.seek(original_pos)
+    end
+
+    char
   end
 
   def close
     @file.close
   end
 
-  private
-
-  def store_to_buffer
-    tmp = @file.readline.chomp!("\r\n")
-    raise Aozora2Html::Error, Aozora2Html::I18n.t(:use_crlf) unless tmp
-
-    @buffer = tmp.each_char.to_a
-    @entry = true
+  # 現在の行数を返す
+  #
+  # 何も読み込む前は0、読み込み始めの最初の文字から\r\nまでが1、その次の文字から次の\r\nは2、……といった値になる
+  def line
+    if @file.pos == 0
+      0
+    elsif @current_char == CRLF
+      @line
+    else
+      @line + 1
+    end
   end
 end

--- a/lib/t2hs.rb
+++ b/lib/t2hs.rb
@@ -335,7 +335,7 @@ class Aozora2Html
       when '-'
         i += 1
       when "\r\n"
-        @section = if i == 0 && @stream.peek_char(1) == "\r\n"
+        @section = if i == 0
                      :body
                    else
                      :chuuki

--- a/test/test_jstream.rb
+++ b/test/test_jstream.rb
@@ -29,8 +29,8 @@ class JstreamTest < Test::Unit::TestCase
     assert_equal 'b', stm.read_char.encode('utf-8')
     assert_equal "\r\n", stm.read_char.encode('utf-8')
     assert_equal :eof, stm.read_char
-    assert_equal "\r\n", stm.read_char  # :eof以降は正しい値を保証しない
-    assert_equal :eof, stm.read_char    # 何度もread_charすると:eofが複数回出る
+    # assert_equal "\r\n", stm.read_char  # :eof以降は正しい値を保証しない
+    assert_equal :eof, stm.read_char # 何度もread_charすると:eofが複数回出る
   end
 
   def test_peek_char
@@ -40,9 +40,9 @@ class JstreamTest < Test::Unit::TestCase
     assert_equal 'あ', stm.peek_char(1).encode('utf-8')
     assert_equal '５', stm.peek_char(2).encode('utf-8')
     assert_equal "\r\n", stm.peek_char(3).encode('utf-8')
-    assert_equal "\r\n", stm.peek_char(4).encode('utf-8') # 改行文字以降は正しい値を保証しない
-    assert_equal "\r\n", stm.peek_char(5).encode('utf-8') # 同上
-    assert_equal "\r\n", stm.peek_char(100).encode('utf-8') # 同上
+    # assert_equal "\r\n", stm.peek_char(4).encode('utf-8') # 改行文字以降は正しい値を保証しない
+    # assert_equal "\r\n", stm.peek_char(5).encode('utf-8') # 同上
+    # assert_equal "\r\n", stm.peek_char(100).encode('utf-8') # 同上
     assert_equal 'a', stm.read_char.encode('utf-8')
 
     assert_equal 'あ', stm.peek_char(0).encode('utf-8')


### PR DESCRIPTION
Jstreamのリファクタリングです。
`@buffer`を使ってバッファリングにしていたところについて、シンプルにするために直接IOから`getc`で一文字ずつ読み込むように修正します。

挙動が微妙なところも若干ありますが、まずは変更しないようにリファクタリングしています。
ただし、テストについて「正しい値を保証しない」のところは値が変わったのでコメントアウトしています。