### PR TITLE
Fix AccentParser; use I18n.t to show warning messages

### DIFF
--- a/lib/aozora2html/accent_parser.rb
+++ b/lib/aozora2html/accent_parser.rb
@@ -73,7 +73,7 @@ class Aozora2Html
         end
         if first == "\r\n"
           if @encount_accent
-            puts "警告(#{line_number}行目):アクセント分解の亀甲括弧の始めと終わりが、行中で揃っていません".encode('shift_jis')
+            puts I18n.t(:warn_invalid_accent_brancket, line_number)
           end
           throw :terminate
         elsif first == '〕'.encode('shift_jis')

--- a/lib/aozora2html/i18n.rb
+++ b/lib/aozora2html/i18n.rb
@@ -21,6 +21,7 @@ class Aozora2Html
       invalid_nesting: '%sを終了しようとしましたが、%s中です',
       dont_use_double_ruby: '同じ箇所に2つのルビはつけられません',
       dont_allow_triple_ruby: '1つの単語に3つのルビはつけられません',
+      warn_invalid_accent_brancket: '警告(%d行目):アクセント分解の亀甲括弧の始めと終わりが、行中で揃っていません',
       warn_unexpected_terminator: '警告(%d行目):予期せぬファイル終端',
       warn_undefined_command: '警告(%d行目):「%s」は未対応のコマンドのため無視します'
     }.freeze

--- a/test/test_aozora_accent_parser.rb
+++ b/test/test_aozora_accent_parser.rb
@@ -16,6 +16,20 @@ class Aozora2HtmlAccentParserTest < Test::Unit::TestCase
     assert_equal expected, parsed.to_s.encode('utf-8')
   end
 
+  def test_invalid
+    str = "〔e'tiquette\r\n".encode('shift_jis')
+    strio = StringIO.new(str)
+    stream = Jstream.new(strio)
+    $stdout = StringIO.new
+    begin
+      _parsed = Aozora2Html::AccentParser.new(stream, '〕'.encode('shift_jis'), {}, [], gaiji_dir: 'g_dir/').process
+      out_str = $stdout.string
+      assert_equal "警告(1行目):アクセント分解の亀甲括弧の始めと終わりが、行中で揃っていません\n", out_str.encode('utf-8')
+    ensure
+      $stdout = STDOUT
+    end
+  end
+
   def test_use_jisx0213
     Aozora2Html::Tag::Accent.use_jisx0213 = true
     str = "〔e'tiquette〕\r\n".encode('shift_jis')


### PR DESCRIPTION
Aozora2Html::AccentParserで日本語エラーメッセージが直接埋め込まれていたのを修正して、I18n.tを使うようにします。