### PR TITLE
Fix #70; Add CLI option `--error-utf8`

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,10 +55,13 @@ $ aozora2html http://example.jp/foo/bar.zip foo.html
 $ aozora2html foo.txt
 ```
 
-コマンドラインオプションとして`--gaiji-dir`と`--use-jisx0213`、`--use-unicode`があります。
-`--gaiji-dir`は外字画像のパスを指定します。
-`--use-jisx0213`はJIS X 0213の外字画像を使わず、数値実体参照として表示します。
-`--use-unicode`はUnicodeのコードポイントが指定されている外字を数値実体参照として表示します。
+コマンドラインオプションとして`--gaiji-dir`と`--css-files`、`--use-jisx0213`、`--use-unicode`、`--error-utf8`があります。
+
+* `--gaiji-dir`は外字画像のパスを指定します。
+* `--css-files`はCSSファイルを`,`区切りで指定します。
+* `--use-jisx0213`はJIS X 0213の外字画像を使わず、数値実体参照として表示します。
+* `--use-unicode`はUnicodeのコードポイントが指定されている外字を数値実体参照として表示します。
+* `--error-utf8`はエラーメッセージをUTF-8で出力するようにします。
 
 可能な限り数値実体参照を使って表示するには、以下のようにオプションを指定します。
 

--- a/bin/aozora2html
+++ b/bin/aozora2html
@@ -11,6 +11,7 @@ opt.on('--gaiji-dir DIR', 'setting gaiji directory')
 opt.on('--css-files FILES', 'setting css directory')
 opt.on('--use-jisx0213', 'use JIS X 0213 character')
 opt.on('--use-unicode', 'use Unicode character')
+opt.on('--error-utf8', 'show error messages in UTF-8, not Shift_JIS')
 opt.version = Aozora2Html::VERSION
 options = opt.getopts
 
@@ -25,6 +26,10 @@ end
 
 if options['use-unicode']
   Aozora2Html::Tag::EmbedGaiji.use_unicode = true
+end
+
+if options['error-utf8']
+  Aozora2Html::I18n.use_utf8 = true
 end
 
 if ARGV.size < 1 || ARGV.size > 2

--- a/lib/aozora2html/i18n.rb
+++ b/lib/aozora2html/i18n.rb
@@ -34,7 +34,8 @@ class Aozora2Html
 
     def self.t(msg, *args)
       if Aozora2Html::I18n.use_utf8
-        (MSG[msg].encode('shift_jis') % args).force_encoding('cp932').encode('utf-8')
+        args_sjis = args.map { |arg| arg.is_a?(String) ? arg.encode('shift_jis') : arg }
+        (MSG[msg].encode('shift_jis') % args_sjis).force_encoding('cp932').encode('utf-8')
       else
         MSG[msg].encode('shift_jis') % args
       end

--- a/lib/aozora2html/i18n.rb
+++ b/lib/aozora2html/i18n.rb
@@ -5,6 +5,12 @@ class Aozora2Html
   #
   # コード内に日本語メッセージが氾濫しないようにするためのクラス
   class I18n
+    @use_utf8 = nil
+
+    class << self
+      attr_accessor :use_utf8
+    end
+
     MSG = {
       tag_syntax_error: '注記を重ねる際の原則、「狭い範囲を先に、広い範囲を後に」が守られていません。リンク先の指針を参考に、書き方をあらためてください',
       undefined_header: '未定義な見出しです',
@@ -27,7 +33,11 @@ class Aozora2Html
     }.freeze
 
     def self.t(msg, *args)
-      (MSG[msg].encode('shift_jis') % args)
+      if Aozora2Html::I18n.use_utf8
+        (MSG[msg].encode('shift_jis') % args).force_encoding('cp932').encode('utf-8')
+      else
+        MSG[msg].encode('shift_jis') % args
+      end
     end
   end
 end

--- a/test/test_i18n.rb
+++ b/test/test_i18n.rb
@@ -12,6 +12,19 @@ class I18nTest < Test::Unit::TestCase
                                   .force_encoding('cp932').encode('utf-8')
   end
 
+  def test_error_utf8
+    orig_value = Aozora2Html::I18n.use_utf8
+    Aozora2Html::I18n.use_utf8 = true
+    begin
+      assert_equal '警告(123行目):JIS外字「①」が使われています',
+                   Aozora2Html::I18n.t(:warn_jis_gaiji,
+                                       123,
+                                       '①'.encode('cp932').force_encoding('shift_jis'))
+    ensure
+      Aozora2Html::I18n.use_utf8 = orig_value
+    end
+  end
+
   def test_ruby_puts_behavior
     $stdout = StringIO.new
     begin


### PR DESCRIPTION
#70 に対応して、`--error-utf8`オプションをつけるとエラーメッセージがUTF-8になるようにします。

現状`I18n.t`はエラーメッセージ出力用にしか使ってないため、上記オプションでI18nクラス全体のエンコーディング設定がUTF-8になるようにしています。
将来的に必要になれば`I18n.t(msg, encoding: 'Shift_JIS')`みたいな18nの設定を無視してエンコーディングを指定するキーワード引数を追加すると良さそうです。