### PR TITLE
Fix RubyBuffer

### DIFF
--- a/lib/aozora2html/ruby_buffer.rb
+++ b/lib/aozora2html/ruby_buffer.rb
@@ -13,14 +13,9 @@ class Aozora2Html
       clear
     end
 
-    # バッファの初期化。引数itemがあるときはその1要素のバッファに、
-    # 引数がなければ`""`の1要素のバッファにする。
-    def clear(item = nil)
-      @ruby_buf = if item
-                    [item]
-                  else
-                    [+'']
-                  end
+    # バッファの初期化。`""`の1要素のバッファにする。
+    def clear
+      @ruby_buf = [+'']
       @protected = nil
       @char_type = nil
     end

--- a/lib/aozora2html/ruby_buffer.rb
+++ b/lib/aozora2html/ruby_buffer.rb
@@ -37,8 +37,24 @@ class Aozora2Html
       @ruby_buf
     end
 
-    def each(&block)
-      @ruby_buf.each(&block)
+    def create_ruby(parser, ruby)
+      ans = +''
+      notes = []
+
+      @ruby_buf.each do |token|
+        if token.is_a?(Aozora2Html::Tag::UnEmbedGaiji)
+          ans.concat(GAIJI_MARK)
+          token.escape!
+          notes.push(token)
+        else
+          ans.concat(token.to_s)
+        end
+      end
+
+      notes.unshift(Aozora2Html::Tag::Ruby.new(parser, ans, ruby))
+      clear
+
+      notes
     end
 
     def last

--- a/lib/aozora2html/ruby_buffer.rb
+++ b/lib/aozora2html/ruby_buffer.rb
@@ -45,20 +45,20 @@ class Aozora2Html
       @ruby_buf.last
     end
 
+    # バッファ末尾にitemを追加する
+    #
+    # itemとバッファの最後尾がどちらもStringであれば連結したStringにし、
+    # そうでなければバッファの末尾に新しい要素として追加する
     def push(item)
-      @ruby_buf.push(item)
+      if last.is_a?(String) && item.is_a?(String)
+        @ruby_buf.last.concat(item)
+      else
+        @ruby_buf.push(item)
+      end
     end
 
     def length
       @ruby_buf.length
-    end
-
-    def last_concat(item)
-      @ruby_buf.last.concat(item)
-    end
-
-    def last_is_string?
-      @ruby_buf.last.is_a?(String)
     end
 
     # buffer management

--- a/lib/t2hs.rb
+++ b/lib/t2hs.rb
@@ -465,7 +465,7 @@ class Aozora2Html
       @ruby_buf.push(char)
     else
       @ruby_buf.dump_into(@buffer)
-      @ruby_buf.clear(char)
+      @ruby_buf.push(char)
       @ruby_buf.char_type = ctype
     end
   end
@@ -525,7 +525,6 @@ class Aozora2Html
     end
     @ruby_buf.dump_into(@buffer)
     buf = @buffer
-    @ruby_buf.clear
     @buffer = []
     tail = []
 
@@ -1442,7 +1441,6 @@ class Aozora2Html
   def tail_output
     @ruby_buf.dump_into(@buffer)
     string = @buffer.join
-    @ruby_buf.clear
     @buffer = []
     string.gsub!('info@aozora.gr.jp', '<a href="mailto: info@aozora.gr.jp">info@aozora.gr.jp</a>')
     string.gsub!('青空文庫（http://www.aozora.gr.jp/）'.to_sjis) { "<a href=\"http://www.aozora.gr.jp/\">#{$&}</a>" }

--- a/lib/t2hs.rb
+++ b/lib/t2hs.rb
@@ -1397,21 +1397,8 @@ class Aozora2Html
       # escaped ruby character
       return RUBY_BEGIN_MARK + RUBY_END_MARK
     end
+    @buffer.concat(@ruby_buf.create_ruby(self, ruby))
 
-    ans = ''
-    notes = []
-    @ruby_buf.each do |token|
-      if token.is_a?(Aozora2Html::Tag::UnEmbedGaiji)
-        ans.concat(GAIJI_MARK)
-        token.escape!
-        notes.push(token)
-      else
-        ans.concat(token.to_s)
-      end
-    end
-    @buffer.push(Aozora2Html::Tag::Ruby.new(self, ans, ruby))
-    @buffer += notes
-    @ruby_buf.clear
     nil
   end
 

--- a/lib/t2hs.rb
+++ b/lib/t2hs.rb
@@ -459,19 +459,10 @@ class Aozora2Html
   def push_char(char)
     ctype = char_type(char)
     if (ctype == :hankaku_terminate) && (@ruby_buf.char_type == :hankaku)
-      if @ruby_buf.last_is_string?
-        @ruby_buf.last_concat(char)
-      else
-        @ruby_buf.push(char)
-      end
+      @ruby_buf.push(char)
       @ruby_buf.char_type = :else
     elsif @ruby_buf.protected || ((ctype != :else) && (ctype == @ruby_buf.char_type))
-      if char.is_a?(String) && @ruby_buf.last_is_string?
-        @ruby_buf.last_concat(char)
-      else
-        @ruby_buf.push(char)
-        @ruby_buf.push('')
-      end
+      @ruby_buf.push(char)
     else
       @ruby_buf.dump_into(@buffer)
       @ruby_buf.clear(char)
@@ -647,11 +638,7 @@ class Aozora2Html
     reference.each do |elt|
       #      if @ruby_buf.protected
       if @ruby_buf.present?
-        if @ruby_buf.last_is_string? && elt.is_a?(String)
-          @ruby_buf.last_concat(elt)
-        else
-          @ruby_buf.push(elt)
-        end
+        @ruby_buf.push(elt)
       elsif @buffer.last.is_a?(String)
         if elt.is_a?(String)
           @buffer.last.concat(elt)

--- a/lib/t2hs.rb
+++ b/lib/t2hs.rb
@@ -644,7 +644,7 @@ class Aozora2Html
         else
           @buffer.push(elt)
         end
-      else
+      else # rubocop:disable Lint/DuplicateBranch
         @ruby_buf.push(elt)
       end
     end
@@ -1396,6 +1396,7 @@ class Aozora2Html
       # escaped ruby character
       return RUBY_BEGIN_MARK + RUBY_END_MARK
     end
+
     @buffer.concat(@ruby_buf.create_ruby(self, ruby))
 
     nil


### PR DESCRIPTION
RubyBufferを修正して、使われないメソッドを削除したりしています。

* `RubyBuffer#push`でStringもそれ以外も受け取れるように修正
* `RubyBuffer#each`を廃止して、t2hs内の処理を`RubyBuffer#create_ruby`メソッドで行うよう修正
* dump_intoを呼んだ後の`@ruby_buf.clear`は不要なので削除