### PR TITLE
Add escape_special_chars

### DIFF
--- a/lib/aozora2html/accent_parser.rb
+++ b/lib/aozora2html/accent_parser.rb
@@ -84,7 +84,7 @@ class Aozora2Html
           @ruby_buf.protected = true
         elsif (first != '') && !first.nil?
           Utils.illegal_char_check(first, line_number)
-          push_chars(first)
+          push_chars(escape_special_chars(first))
         end
       end
     end

--- a/lib/aozora2html/tag/reference_mentioned.rb
+++ b/lib/aozora2html/tag/reference_mentioned.rb
@@ -19,12 +19,7 @@ class Aozora2Html
       def block_element?(elt)
         case elt
         when Array
-          elt.each do |x|
-            if block_element?(x)
-              return true
-            end
-          end
-          nil
+          elt.any? { |x| block_element?(x) }
         when String
           elt.include?('<div')
         else

--- a/lib/t2hs.rb
+++ b/lib/t2hs.rb
@@ -417,7 +417,7 @@ class Aozora2Html
       if check
         Utils.illegal_char_check(char, line_number)
       end
-      push_chars(char)
+      push_chars(escape_special_chars(char))
     end
   end
 
@@ -445,9 +445,6 @@ class Aozora2Html
         push_chars(x)
       end
     when String
-      if obj.length == 1
-        obj = obj.gsub(/[&"<>]/, { '&' => '&amp;', '"' => '&quot;', '<' => '&lt;', '>' => '&gt;' })
-      end
       obj.each_char do |x|
         push_char(x)
       end
@@ -1434,7 +1431,7 @@ class Aozora2Html
       if check
         Utils.illegal_char_check(char, line_number)
       end
-      push_chars(char)
+      push_chars(escape_special_chars(char))
     end
   end
 
@@ -1500,5 +1497,13 @@ class Aozora2Html
       @out.print "</ul>\r\n" # <ul>内に<li>以外のエレメントが来るのは不正なので修正
     end
     @out.print "</div>\r\n"
+  end
+
+  def escape_special_chars(char)
+    if char.is_a?(String)
+      char.gsub(/[&"<>]/, { '&' => '&amp;', '"' => '&quot;', '<' => '&lt;', '>' => '&gt;' })
+    else
+      char
+    end
   end
 end

--- a/lib/t2hs.rb
+++ b/lib/t2hs.rb
@@ -435,9 +435,6 @@ class Aozora2Html
     # rubocop:enable Style/GuardClause
   end
 
-  # Original Aozora2Html#push_chars does not convert "'" into '&#39;'; it's old behaivor
-  # of CGI.escapeHTML().
-  #
   def push_chars(obj)
     case obj
     when Array
@@ -1499,6 +1496,7 @@ class Aozora2Html
     @out.print "</div>\r\n"
   end
 
+  # Original Aozora2Html#push_chars does not convert "'" into '&#39;'; it's old behaivor of CGI.escapeHTML().
   def escape_special_chars(char)
     if char.is_a?(String)
       char.gsub(/[&"<>]/, { '&' => '&amp;', '"' => '&quot;', '<' => '&lt;', '>' => '&gt;' })


### PR DESCRIPTION
`push_chars`内で（長さ1の文字列の場合だけ？）HTMLエスケープをするのはおかしいので、`push_chars`する前にエスケープするよう修正します。