### PR TITLE
refactor: change Tag::Block and Tag::Inline to class from module

### DIFF
--- a/lib/aozora2html/tag/accent.rb
+++ b/lib/aozora2html/tag/accent.rb
@@ -3,14 +3,12 @@
 class Aozora2Html
   class Tag
     # 欧文アクセント文字用
-    class Accent < Aozora2Html::Tag
+    class Accent < Aozora2Html::Tag::Inline
       @use_jisx0213 = nil
 
       class << self
         attr_accessor :use_jisx0213
       end
-
-      include Aozora2Html::Tag::Inline
 
       def initialize(parser, code, name, gaiji_dir:)
         @code = code

--- a/lib/aozora2html/tag/block.rb
+++ b/lib/aozora2html/tag/block.rb
@@ -2,10 +2,10 @@
 
 class Aozora2Html
   class Tag
-    # ブロックタグ用module
+    # ブロックタグ用class
     #
-    # 各Tagクラスにてincludeして使う
-    module Block
+    # 各Tagクラスはこれを継承する
+    class Block
       def initialize(parser, *_args)
         if parser.block_allowed_context?
           nil

--- a/lib/aozora2html/tag/dakuten_katakana.rb
+++ b/lib/aozora2html/tag/dakuten_katakana.rb
@@ -3,9 +3,7 @@
 class Aozora2Html
   class Tag
     # 濁点つきカタカナ用
-    class DakutenKatakana < Aozora2Html::Tag
-      include Aozora2Html::Tag::Inline
-
+    class DakutenKatakana < Aozora2Html::Tag::Inline
       def initialize(parser, num, katakana, gaiji_dir:)
         @n = num
         @katakana = katakana

--- a/lib/aozora2html/tag/editor_note.rb
+++ b/lib/aozora2html/tag/editor_note.rb
@@ -3,8 +3,7 @@
 class Aozora2Html
   class Tag
     # 編集者による訂正用
-    class EditorNote < Aozora2Html::Tag
-      include Aozora2Html::Tag::Inline
+    class EditorNote < Aozora2Html::Tag::Inline
       def initialize(parser, desc)
         @desc = desc
         super

--- a/lib/aozora2html/tag/font_size.rb
+++ b/lib/aozora2html/tag/font_size.rb
@@ -3,9 +3,8 @@
 class Aozora2Html
   class Tag
     # フォントサイズ指定用
-    class FontSize < Aozora2Html::Tag
+    class FontSize < Aozora2Html::Tag::Block
       include Aozora2Html::Tag::Multiline
-      include Aozora2Html::Tag::Block
 
       def initialize(parser, times, daisho)
         @class = daisho.to_s + times.to_s

--- a/lib/aozora2html/tag/gaiji.rb
+++ b/lib/aozora2html/tag/gaiji.rb
@@ -3,9 +3,7 @@
 class Aozora2Html
   class Tag
     # 外字用
-    class Gaiji < Aozora2Html::Tag
-      include Aozora2Html::Tag::Inline
-
+    class Gaiji < Aozora2Html::Tag::Inline
       def char_type
         :kanji
       end

--- a/lib/aozora2html/tag/img.rb
+++ b/lib/aozora2html/tag/img.rb
@@ -3,9 +3,7 @@
 class Aozora2Html
   class Tag
     # 画像用
-    class Img < Aozora2Html::Tag
-      include Aozora2Html::Tag::Inline
-
+    class Img < Aozora2Html::Tag::Inline
       def initialize(parser, filename, css_class, alt, width, height)
         @filename = filename
         @css_class = css_class

--- a/lib/aozora2html/tag/indent.rb
+++ b/lib/aozora2html/tag/indent.rb
@@ -2,8 +2,7 @@
 
 class Aozora2Html
   class Tag
-    class Indent < Aozora2Html::Tag
-      include Aozora2Html::Tag::Block
+    class Indent < Aozora2Html::Tag::Block
     end
   end
 end

--- a/lib/aozora2html/tag/inline.rb
+++ b/lib/aozora2html/tag/inline.rb
@@ -2,12 +2,12 @@
 
 class Aozora2Html
   class Tag
-    # インライン記法用
+    # インラインタグ用class
     #
     # 全ての青空記法はHTML elementに変換される
     # したがって、block/inlineの区別がある
-    # 全ての末端青空classはどちらかのmoduleをincludeする必要がある
-    module Inline
+    # 全ての末端青空classはどちらかのclassのサブクラスになる必要がある
+    class Inline
       def initialize(*_args)
         true
       end

--- a/lib/aozora2html/tag/keigakomi.rb
+++ b/lib/aozora2html/tag/keigakomi.rb
@@ -3,9 +3,8 @@
 class Aozora2Html
   class Tag
     # 罫囲み用
-    class Keigakomi < Aozora2Html::Tag
+    class Keigakomi < Aozora2Html::Tag::Block
       include Aozora2Html::Tag::Multiline
-      include Aozora2Html::Tag::Block
 
       def initialize(parser, size = 1)
         @size = size

--- a/lib/aozora2html/tag/kunten.rb
+++ b/lib/aozora2html/tag/kunten.rb
@@ -3,9 +3,7 @@
 class Aozora2Html
   class Tag
     # 訓点用
-    class Kunten < Aozora2Html::Tag
-      include Aozora2Html::Tag::Inline
-
+    class Kunten < Aozora2Html::Tag::Inline
       def char_type
         :else # just remove this line
       end

--- a/lib/aozora2html/tag/multiline_caption.rb
+++ b/lib/aozora2html/tag/multiline_caption.rb
@@ -3,10 +3,8 @@
 class Aozora2Html
   class Tag
     # 複数行キャプション用
-    class MultilineCaption < Aozora2Html::Tag
+    class MultilineCaption < Aozora2Html::Tag::Block
       include Aozora2Html::Tag::Multiline
-      include Aozora2Html::Tag::Block
-
       def to_s
         '<div class="caption">'
       end

--- a/lib/aozora2html/tag/multiline_midashi.rb
+++ b/lib/aozora2html/tag/multiline_midashi.rb
@@ -3,9 +3,8 @@
 class Aozora2Html
   class Tag
     # ブロックでの見出し指定用
-    class MultilineMidashi < Aozora2Html::Tag
+    class MultilineMidashi < Aozora2Html::Tag::Block
       include Aozora2Html::Tag::Multiline
-      include Aozora2Html::Tag::Block
 
       def initialize(parser, size, type)
         super

--- a/lib/aozora2html/tag/multiline_style.rb
+++ b/lib/aozora2html/tag/multiline_style.rb
@@ -3,9 +3,8 @@
 class Aozora2Html
   class Tag
     # ブロックでのスタイル指定用
-    class MultilineStyle < Aozora2Html::Tag
+    class MultilineStyle < Aozora2Html::Tag::Block
       include Aozora2Html::Tag::Multiline
-      include Aozora2Html::Tag::Block
 
       def initialize(parser, style)
         @style = style

--- a/lib/aozora2html/tag/multiline_yokogumi.rb
+++ b/lib/aozora2html/tag/multiline_yokogumi.rb
@@ -3,9 +3,8 @@
 class Aozora2Html
   class Tag
     # ブロックでの横組指定用
-    class MultilineYokogumi < Aozora2Html::Tag
+    class MultilineYokogumi < Aozora2Html::Tag::Block
       include Aozora2Html::Tag::Multiline
-      include Aozora2Html::Tag::Block
 
       def to_s
         '<div class="yokogumi">'

--- a/lib/aozora2html/tag/reference_mentioned.rb
+++ b/lib/aozora2html/tag/reference_mentioned.rb
@@ -6,8 +6,7 @@ class Aozora2Html
     #
     # 前方参照でこいつだけは中身をチェックする
     # 子要素を持つAozora2Html::Tag::Inlineは全てこいつのサブクラス
-    class ReferenceMentioned < Aozora2Html::Tag
-      include Aozora2Html::Tag::Inline
+    class ReferenceMentioned < Aozora2Html::Tag::Inline
       attr_accessor :target
 
       def initialize(*_args) # rubocop:disable Lint/MissingSuper


### PR DESCRIPTION
BlockとInlineがmoduleとして実装されている割にはinitializeの継承関係が重要なようなので、ふつうにclassにしてみます。
`Aozora2Html::Tag::Multiline`はmoduleのままで、必要に応じてincludeする想定です。