### PR TITLE
refactor: move char_type into RubyBuffer

### DIFF
--- a/lib/aozora2html/ruby_buffer.rb
+++ b/lib/aozora2html/ruby_buffer.rb
@@ -6,9 +6,6 @@ class Aozora2Html
     # `｜`が来た時に真にする。ルビの親文字のガード用。
     attr_accessor :protected
 
-    # @ruby_buf内の文字のchar_type
-    attr_accessor :char_type
-
     def initialize
       clear
     end
@@ -87,6 +84,29 @@ class Aozora2Html
       end
       clear
       buffer
+    end
+
+    def push_char(char, buffer)
+      ctype = char_type(char)
+      if (ctype == :hankaku_terminate) && (@char_type == :hankaku)
+        push(char)
+        @char_type = :else
+      elsif @protected || ((ctype != :else) && (ctype == @char_type))
+        push(char)
+      else
+        dump_into(buffer)
+        push(char)
+        @char_type = ctype
+      end
+    end
+
+    private
+
+    def char_type(char)
+      ## `String#char_type`も定義されているのに注意
+      char.char_type
+    rescue StandardError
+      :else
     end
   end
 end

--- a/lib/extensions.rb
+++ b/lib/extensions.rb
@@ -2,7 +2,7 @@
 
 # String extension
 class String
-  # used in Aozora2Html#char_type
+  # used in RubyBuffer#char_type
   def char_type
     ch = self
     if ch.match(Aozora2Html::REGEX_HIRAGANA)

--- a/lib/t2hs.rb
+++ b/lib/t2hs.rb
@@ -237,13 +237,6 @@ class Aozora2Html
     raise e
   end
 
-  def char_type(char)
-    ## `String#char_type`も定義されているのに注意
-    char.char_type
-  rescue StandardError
-    :else
-  end
-
   def finalize
     hyoki
     dynamic_contents
@@ -458,17 +451,7 @@ class Aozora2Html
   end
 
   def push_char(char)
-    ctype = char_type(char)
-    if (ctype == :hankaku_terminate) && (@ruby_buf.char_type == :hankaku)
-      @ruby_buf.push(char)
-      @ruby_buf.char_type = :else
-    elsif @ruby_buf.protected || ((ctype != :else) && (ctype == @ruby_buf.char_type))
-      @ruby_buf.push(char)
-    else
-      @ruby_buf.dump_into(@buffer)
-      @ruby_buf.push(char)
-      @ruby_buf.char_type = ctype
-    end
+    @ruby_buf.push_char(char, @buffer)
   end
 
   # 読み込んだ行の出力を行う

--- a/test/test_aozora2html.rb
+++ b/test/test_aozora2html.rb
@@ -87,24 +87,24 @@ class Aozora2HtmlTest < Test::Unit::TestCase
   end
 
   def test_char_type
-    assert_equal :kanji, @parser.char_type(Aozora2Html::Tag::EmbedGaiji.new(nil, 'foo', '1-2-3', 'name', gaiji_dir: nil))
-    assert_equal :kanji, @parser.char_type(Aozora2Html::Tag::UnEmbedGaiji.new(nil, 'foo'))
-    assert_equal :hankaku, @parser.char_type(Aozora2Html::Tag::Accent.new(nil, 123, 'abc', gaiji_dir: nil))
-    assert_equal :else, @parser.char_type(Aozora2Html::Tag::Okurigana.new(nil, 'abc'))
-    assert_equal :else, @parser.char_type(Aozora2Html::Tag::InlineKeigakomi.new(nil, 'abc'))
-    assert_equal :katakana, @parser.char_type(Aozora2Html::Tag::DakutenKatakana.new(nil, 1, 'abc', gaiji_dir: nil))
+    assert_equal :kanji, Aozora2Html::Tag::EmbedGaiji.new(nil, 'foo', '1-2-3', 'name', gaiji_dir: nil).char_type
+    assert_equal :kanji, Aozora2Html::Tag::UnEmbedGaiji.new(nil, 'foo').char_type
+    assert_equal :hankaku, Aozora2Html::Tag::Accent.new(nil, 123, 'abc', gaiji_dir: nil).char_type
+    assert_equal :else, Aozora2Html::Tag::Okurigana.new(nil, 'abc').char_type
+    assert_equal :else, Aozora2Html::Tag::InlineKeigakomi.new(nil, 'abc').char_type
+    assert_equal :katakana, Aozora2Html::Tag::DakutenKatakana.new(nil, 1, 'abc', gaiji_dir: nil).char_type
 
-    assert_equal :hiragana, @parser.char_type('あ'.encode('shift_jis'))
-    assert_equal :hiragana, @parser.char_type('っ'.encode('shift_jis'))
-    assert_equal :katakana, @parser.char_type('ヴ'.encode('shift_jis'))
-    assert_equal :katakana, @parser.char_type('ー'.encode('shift_jis'))
-    assert_equal :zenkaku, @parser.char_type('Ａ'.encode('shift_jis'))
-    assert_equal :zenkaku, @parser.char_type('ｗ'.encode('shift_jis'))
-    assert_equal :hankaku, @parser.char_type('z'.encode('shift_jis'))
-    assert_equal :kanji, @parser.char_type('漢'.encode('shift_jis'))
-    assert_equal :hankaku_terminate, @parser.char_type('!'.encode('shift_jis'))
-    assert_equal :else, @parser.char_type('？'.encode('shift_jis'))
-    assert_equal :else, @parser.char_type('Å'.encode('shift_jis'))
+    assert_equal :hiragana, 'あ'.encode('shift_jis').char_type
+    assert_equal :hiragana, 'っ'.encode('shift_jis').char_type
+    assert_equal :katakana, 'ヴ'.encode('shift_jis').char_type
+    assert_equal :katakana, 'ー'.encode('shift_jis').char_type
+    assert_equal :zenkaku, 'Ａ'.encode('shift_jis').char_type
+    assert_equal :zenkaku, 'ｗ'.encode('shift_jis').char_type
+    assert_equal :hankaku, 'z'.encode('shift_jis').char_type
+    assert_equal :kanji, '漢'.encode('shift_jis').char_type
+    assert_equal :hankaku_terminate, '!'.encode('shift_jis').char_type
+    assert_equal :else, '？'.encode('shift_jis').char_type
+    assert_equal :else, 'Å'.encode('shift_jis').char_type
   end
 
   def test_read_char


### PR DESCRIPTION
and remove public method `RubyBuffer#char_type`

`char_type`は詰まるところRubyBuffer内部のハンドリング（ルビ候補として読み込まれた文字の種別と、バッファ内の文字列の種別を比較してバッファに貯め続けるか吐き出すかを決める）にしか使われないはずなので、Aozora2Htmlのparser本体ではなくRubyBuffer内部のメソッドに変更し、外部から読み書きできないようにします。