### PR TITLE
Refactor: Use more to_sjis and (new) to_utf8

### DIFF
--- a/lib/aozora2html/i18n.rb
+++ b/lib/aozora2html/i18n.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative 'string_refinements'
+
 class Aozora2Html
   # Internationalization(I18n) class
   #
@@ -32,12 +34,14 @@ class Aozora2Html
       warn_undefined_command: '警告(%d行目):「%s」は未対応のコマンドのため無視します'
     }.freeze
 
+    using StringRefinements
+
     def self.t(msg, *args)
       if Aozora2Html::I18n.use_utf8
-        args_sjis = args.map { |arg| arg.is_a?(String) ? arg.encode('shift_jis') : arg }
-        (MSG[msg].encode('shift_jis') % args_sjis).force_encoding('cp932').encode('utf-8')
+        args_sjis = args.map { |arg| arg.is_a?(String) ? arg.to_sjis : arg }
+        (MSG[msg].to_sjis % args_sjis).force_encoding('cp932').to_utf8
       else
-        MSG[msg].encode('shift_jis') % args
+        MSG[msg].to_sjis % args
       end
     end
   end

--- a/lib/aozora2html/string_refinements.rb
+++ b/lib/aozora2html/string_refinements.rb
@@ -25,7 +25,11 @@ class Aozora2Html
       end
 
       def to_sjis
-        encode('shift_jis')
+        encode(Encoding::Shift_JIS)
+      end
+
+      def to_utf8
+        encode(Encoding::UTF_8)
       end
     end
   end

--- a/lib/aozora2html/tag/dakuten_katakana.rb
+++ b/lib/aozora2html/tag/dakuten_katakana.rb
@@ -15,8 +15,10 @@ class Aozora2Html
         :katakana
       end
 
+      using StringRefinements
+
       def to_s
-        "<img src=\"#{@gaiji_dir}/1-07/1-07-8#{@n}.png\" alt=\"" + '※(濁点付き片仮名「'.encode('shift_jis') + @katakana + '」、1-07-8'.encode('shift_jis') + "#{@n})\" class=\"gaiji\" />"
+        "<img src=\"#{@gaiji_dir}/1-07/1-07-8#{@n}.png\" alt=\"" + '※(濁点付き片仮名「'.to_sjis + @katakana + '」、1-07-8'.to_sjis + "#{@n})\" class=\"gaiji\" />"
       end
     end
   end

--- a/lib/aozora2html/tag/editor_note.rb
+++ b/lib/aozora2html/tag/editor_note.rb
@@ -9,8 +9,10 @@ class Aozora2Html
         super
       end
 
+      using StringRefinements
+
       def to_s
-        '<span class="notes">［＃'.encode('shift_jis') + @desc + '］</span>'.encode('shift_jis')
+        '<span class="notes">［＃'.to_sjis + @desc + '］</span>'.to_sjis
       end
     end
   end

--- a/lib/aozora2html/tag/un_embed_gaiji.rb
+++ b/lib/aozora2html/tag/un_embed_gaiji.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative '../string_refinements'
+
 class Aozora2Html
   class Tag
     # 非埋め込み外字
@@ -10,8 +12,10 @@ class Aozora2Html
         super
       end
 
+      using StringRefinements
+
       def to_s
-        '<span class="notes">［'.encode('shift_jis') + @desc + '］</span>'.encode('shift_jis')
+        '<span class="notes">［'.to_sjis + @desc + '］</span>'.to_sjis
       end
 
       def escaped?

--- a/lib/aozora2html/utils.rb
+++ b/lib/aozora2html/utils.rb
@@ -3,9 +3,11 @@
 class Aozora2Html
   # ユーティリティ関数モジュール
   module Utils
-    KANJI_NUMS = '一二三四五六七八九〇'.encode('shift_jis')
-    KANJI_TEN = '十'.encode('shift_jis')
-    ZENKAKU_NUMS = '０-９'.encode('shift_jis')
+    using StringRefinements
+
+    KANJI_NUMS = '一二三四五六七八九〇'.to_sjis
+    KANJI_TEN = '十'.to_sjis
+    ZENKAKU_NUMS = '０-９'.to_sjis
 
     def create_font_size(times, daisho)
       size = case times

--- a/lib/aozora2html/yaml_loader.rb
+++ b/lib/aozora2html/yaml_loader.rb
@@ -14,10 +14,12 @@ class Aozora2Html
       normalize_data(tmp_data)
     end
 
+    using StringRefinements
+
     def normalize_data(data)
       case data
       when String
-        data.encode('shift_jis')
+        data.to_sjis
       when Hash
         new_data = {}
         data.each do |k, v|

--- a/lib/t2hs.rb
+++ b/lib/t2hs.rb
@@ -104,11 +104,11 @@ class Aozora2Html
   PAT_BOUKI = /#{"「(.)」の傍記".to_sjis}/.freeze
   PAT_CHARSIZE = /#{"(.*)段階(..)な文字".to_sjis}/.freeze
 
-  REGEX_HIRAGANA = Regexp.new('[ぁ-んゝゞ]'.encode('shift_jis'))
-  REGEX_KATAKANA = Regexp.new('[ァ-ンーヽヾヴ]'.encode('shift_jis'))
-  REGEX_ZENKAKU = Regexp.new('[０-９Ａ-Ｚａ-ｚΑ-Ωα-ωА-Яа-я−＆’，．]'.encode('shift_jis'))
-  REGEX_HANKAKU = Regexp.new("[A-Za-z0-9#\\-\\&'\\,]".encode('shift_jis'))
-  REGEX_KANJI = Regexp.new('[亜-熙々※仝〆〇ヶ]'.encode('shift_jis'))
+  REGEX_HIRAGANA = Regexp.new('[ぁ-んゝゞ]'.to_sjis)
+  REGEX_KATAKANA = Regexp.new('[ァ-ンーヽヾヴ]'.to_sjis)
+  REGEX_ZENKAKU = Regexp.new('[０-９Ａ-Ｚａ-ｚΑ-Ωα-ωА-Яа-я−＆’，．]'.to_sjis)
+  REGEX_HANKAKU = Regexp.new("[A-Za-z0-9#\\-\\&'\\,]".to_sjis)
+  REGEX_KANJI = Regexp.new('[亜-熙々※仝〆〇ヶ]'.to_sjis)
 
   DYNAMIC_CONTENTS = "<div id=\"card\">\r\n<hr />\r\n<br />\r\n<a href=\"JavaScript:goLibCard();\" id=\"goAZLibCard\">●図書カード</a><script type=\"text/javascript\" src=\"../../contents.js\"></script>\r\n<script type=\"text/javascript\" src=\"../../golibcard.js\"></script>\r\n</div>".to_sjis
 

--- a/test/test_aozora2html.rb
+++ b/test/test_aozora2html.rb
@@ -96,25 +96,25 @@ class Aozora2HtmlTest < Test::Unit::TestCase
     assert_equal :else, Aozora2Html::Tag::InlineKeigakomi.new(nil, 'abc').char_type
     assert_equal :katakana, Aozora2Html::Tag::DakutenKatakana.new(nil, 1, 'abc', gaiji_dir: nil).char_type
 
-    assert_equal :hiragana, 'あ'.encode('shift_jis').char_type
-    assert_equal :hiragana, 'っ'.encode('shift_jis').char_type
-    assert_equal :katakana, 'ヴ'.encode('shift_jis').char_type
-    assert_equal :katakana, 'ー'.encode('shift_jis').char_type
-    assert_equal :zenkaku, 'Ａ'.encode('shift_jis').char_type
-    assert_equal :zenkaku, 'ｗ'.encode('shift_jis').char_type
-    assert_equal :hankaku, 'z'.encode('shift_jis').char_type
-    assert_equal :kanji, '漢'.encode('shift_jis').char_type
-    assert_equal :hankaku_terminate, '!'.encode('shift_jis').char_type
-    assert_equal :else, '？'.encode('shift_jis').char_type
-    assert_equal :else, 'Å'.encode('shift_jis').char_type
+    assert_equal :hiragana, 'あ'.to_sjis.char_type
+    assert_equal :hiragana, 'っ'.to_sjis.char_type
+    assert_equal :katakana, 'ヴ'.to_sjis.char_type
+    assert_equal :katakana, 'ー'.to_sjis.char_type
+    assert_equal :zenkaku, 'Ａ'.to_sjis.char_type
+    assert_equal :zenkaku, 'ｗ'.to_sjis.char_type
+    assert_equal :hankaku, 'z'.to_sjis.char_type
+    assert_equal :kanji, '漢'.to_sjis.char_type
+    assert_equal :hankaku_terminate, '!'.to_sjis.char_type
+    assert_equal :else, '？'.to_sjis.char_type
+    assert_equal :else, 'Å'.to_sjis.char_type
   end
 
   def test_read_char
-    input = StringIO.new("／＼\r\n".encode('shift_jis'))
+    input = StringIO.new("／＼\r\n".to_sjis)
     output = StringIO.new
     parser = Aozora2Html.new(input, output)
     char = parser.read_char
-    assert_equal '／'.encode('shift_jis'), char
+    assert_equal '／'.to_sjis, char
     assert_equal Aozora2Html::KU, char
   end
 
@@ -124,7 +124,7 @@ class Aozora2HtmlTest < Test::Unit::TestCase
     begin
       Aozora2Html::Utils.illegal_char_check('#', 123)
       outstr = out.string
-      assert_equal "警告(123行目):1バイトの「#」が使われています\n", outstr.encode('utf-8')
+      assert_equal "警告(123行目):1バイトの「#」が使われています\n", outstr.to_utf8
     ensure
       $stdout = STDOUT
     end
@@ -134,9 +134,9 @@ class Aozora2HtmlTest < Test::Unit::TestCase
     out = StringIO.new
     $stdout = out
     begin
-      Aozora2Html::Utils.illegal_char_check('♯'.encode('shift_jis'), 123)
+      Aozora2Html::Utils.illegal_char_check('♯'.to_sjis, 123)
       outstr = out.string
-      assert_equal "警告(123行目):注記記号の誤用の可能性がある、「♯」が使われています\n", outstr.encode('utf-8')
+      assert_equal "警告(123行目):注記記号の誤用の可能性がある、「♯」が使われています\n", outstr.to_utf8
     ensure
       $stdout = STDOUT
     end
@@ -148,7 +148,7 @@ class Aozora2HtmlTest < Test::Unit::TestCase
     begin
       Aozora2Html::Utils.illegal_char_check('①'.encode('cp932').force_encoding('shift_jis'), 123)
       outstr = out.string
-      assert_equal "警告(123行目):JIS外字「①」が使われています\n", outstr.force_encoding('cp932').encode('utf-8')
+      assert_equal "警告(123行目):JIS外字「①」が使われています\n", outstr.force_encoding('cp932').to_utf8
     ensure
       $stdout = STDOUT
     end
@@ -158,7 +158,7 @@ class Aozora2HtmlTest < Test::Unit::TestCase
     out = StringIO.new
     $stdout = out
     begin
-      Aozora2Html::Utils.illegal_char_check('あ'.encode('shift_jis'), 123)
+      Aozora2Html::Utils.illegal_char_check('あ'.to_sjis, 123)
       outstr = out.string
       assert_equal '', outstr
     ensure
@@ -168,37 +168,37 @@ class Aozora2HtmlTest < Test::Unit::TestCase
 
   def test_convert_japanese_number
     assert_equal '3字下げ',
-                 Aozora2Html::Utils.convert_japanese_number('三字下げ'.encode('shift_jis')).encode('utf-8')
+                 Aozora2Html::Utils.convert_japanese_number('三字下げ'.to_sjis).to_utf8
     assert_equal '10字下げ',
-                 Aozora2Html::Utils.convert_japanese_number('十字下げ'.encode('shift_jis')).encode('utf-8')
+                 Aozora2Html::Utils.convert_japanese_number('十字下げ'.to_sjis).to_utf8
     assert_equal '12字下げ',
-                 Aozora2Html::Utils.convert_japanese_number('十二字下げ'.encode('shift_jis')).encode('utf-8')
+                 Aozora2Html::Utils.convert_japanese_number('十二字下げ'.to_sjis).to_utf8
     assert_equal '20字下げ',
-                 Aozora2Html::Utils.convert_japanese_number('二十字下げ'.encode('shift_jis')).encode('utf-8')
+                 Aozora2Html::Utils.convert_japanese_number('二十字下げ'.to_sjis).to_utf8
     assert_equal '20字下げ',
-                 Aozora2Html::Utils.convert_japanese_number('二〇字下げ'.encode('shift_jis')).encode('utf-8')
+                 Aozora2Html::Utils.convert_japanese_number('二〇字下げ'.to_sjis).to_utf8
     assert_equal '23字下げ',
-                 Aozora2Html::Utils.convert_japanese_number('二十三字下げ'.encode('shift_jis')).encode('utf-8')
+                 Aozora2Html::Utils.convert_japanese_number('二十三字下げ'.to_sjis).to_utf8
     assert_equal '2字下げ',
-                 Aozora2Html::Utils.convert_japanese_number('２字下げ'.encode('shift_jis')).encode('utf-8')
+                 Aozora2Html::Utils.convert_japanese_number('２字下げ'.to_sjis).to_utf8
   end
 
   def test_kuten2png
     assert_equal %q|<img src="../../../gaiji/1-84/1-84-77.png" alt="※(「てへん＋劣」、第3水準1-84-77)" class="gaiji" />|,
-                 @parser.kuten2png('＃「てへん＋劣」、第3水準1-84-77'.encode('shift_jis')).to_s.encode('utf-8')
+                 @parser.kuten2png('＃「てへん＋劣」、第3水準1-84-77'.to_sjis).to_s.to_utf8
     assert_equal %q|<img src="../../../gaiji/1-02/1-02-22.png" alt="※(二の字点、1-2-22)" class="gaiji" />|,
-                 @parser.kuten2png('＃二の字点、1-2-22'.encode('shift_jis')).to_s.encode('utf-8')
+                 @parser.kuten2png('＃二の字点、1-2-22'.to_sjis).to_s.to_utf8
     assert_equal %q|<img src="../../../gaiji/1-06/1-06-57.png" alt="※(ファイナルシグマ、1-6-57)" class="gaiji" />|,
-                 @parser.kuten2png('＃ファイナルシグマ、1-6-57'.encode('shift_jis')).to_s.encode('utf-8')
+                 @parser.kuten2png('＃ファイナルシグマ、1-6-57'.to_sjis).to_s.to_utf8
     assert_equal %q(＃「口＋世」、151-23),
-                 @parser.kuten2png('＃「口＋世」、151-23'.encode('shift_jis')).to_s.encode('utf-8')
+                 @parser.kuten2png('＃「口＋世」、151-23'.to_sjis).to_s.to_utf8
   end
 
   def test_terpri?
     assert_equal true, Aozora2Html::TextBuffer.new.terpri?
     assert_equal true, Aozora2Html::TextBuffer.new(['']).terpri?
     assert_equal true, Aozora2Html::TextBuffer.new(['a']).terpri?
-    tag = Aozora2Html::Tag::MultilineMidashi.new(@parser, '小'.encode('shift_jis'), :normal)
+    tag = Aozora2Html::Tag::MultilineMidashi.new(@parser, '小'.to_sjis, :normal)
     assert_equal false, Aozora2Html::TextBuffer.new([tag]).terpri?
     assert_equal false, Aozora2Html::TextBuffer.new([tag, tag]).terpri?
     assert_equal false, Aozora2Html::TextBuffer.new([tag, '', '']).terpri?
@@ -210,11 +210,11 @@ class Aozora2HtmlTest < Test::Unit::TestCase
   def test_new_midashi_id
     midashi_id = @parser.new_midashi_id(1)
     assert_equal midashi_id + 1, @parser.new_midashi_id(1)
-    assert_equal midashi_id + 2, @parser.new_midashi_id('小'.encode('shift_jis'))
-    assert_equal midashi_id + 12, @parser.new_midashi_id('中'.encode('shift_jis'))
-    assert_equal midashi_id + 112, @parser.new_midashi_id('大'.encode('shift_jis'))
+    assert_equal midashi_id + 2, @parser.new_midashi_id('小'.to_sjis)
+    assert_equal midashi_id + 12, @parser.new_midashi_id('中'.to_sjis)
+    assert_equal midashi_id + 112, @parser.new_midashi_id('大'.to_sjis)
     assert_raise(Aozora2Html::Error) do
-      @parser.new_midashi_id('？'.encode('shift_jis'))
+      @parser.new_midashi_id('？'.to_sjis)
     end
   end
 
@@ -224,25 +224,25 @@ class Aozora2HtmlTest < Test::Unit::TestCase
   end
 
   def test_apply_midashi
-    midashi = @parser.apply_midashi('中見出し'.encode('shift_jis'))
+    midashi = @parser.apply_midashi('中見出し'.to_sjis)
     assert_equal %Q(<h4 class="naka-midashi"><a class="midashi_anchor" id="midashi10">), midashi.to_s
-    midashi = @parser.apply_midashi('大見出し'.encode('shift_jis'))
+    midashi = @parser.apply_midashi('大見出し'.to_sjis)
     assert_equal %Q(<h3 class="o-midashi"><a class="midashi_anchor" id="midashi110">), midashi.to_s
   end
 
   def test_detect_command_mode
-    command = '字下げ終わり'.encode('shift_jis')
+    command = '字下げ終わり'.to_sjis
     assert_equal :jisage, @parser.detect_command_mode(command)
-    command = '地付き終わり'.encode('shift_jis')
+    command = '地付き終わり'.to_sjis
     assert_equal :chitsuki, @parser.detect_command_mode(command)
-    command = '中見出し終わり'.encode('shift_jis')
+    command = '中見出し終わり'.to_sjis
     assert_equal :midashi, @parser.detect_command_mode(command)
-    command = 'ここで太字終わり'.encode('shift_jis')
+    command = 'ここで太字終わり'.to_sjis
     assert_equal :futoji, @parser.detect_command_mode(command)
   end
 
   def test_tcy
-    input = StringIO.new("［＃縦中横］（※［＃ローマ数字1、1-13-21］）\r\n".encode('shift_jis'))
+    input = StringIO.new("［＃縦中横］（※［＃ローマ数字1、1-13-21］）\r\n".to_sjis)
     output = StringIO.new
     parser = Aozora2Html.new(input, output)
     out = StringIO.new
@@ -252,7 +252,7 @@ class Aozora2HtmlTest < Test::Unit::TestCase
       parser.parse_body
       parser.general_output
     rescue Aozora2Html::Error => e
-      message = e.message.encode('utf-8')
+      message = e.message.to_utf8
     ensure
       $stdout = STDOUT
       assert_equal "エラー(0行目):縦中横中に改行されました。改行をまたぐ要素にはブロック表記を用いてください. \r\n処理を停止します", message
@@ -260,7 +260,7 @@ class Aozora2HtmlTest < Test::Unit::TestCase
   end
 
   def test_ensure_close
-    input = StringIO.new("［＃ここから５字下げ］\r\n底本： test\r\n".encode('shift_jis'))
+    input = StringIO.new("［＃ここから５字下げ］\r\n底本： test\r\n".to_sjis)
     output = StringIO.new
     parser = Aozora2Html.new(input, output)
     out = StringIO.new
@@ -272,7 +272,7 @@ class Aozora2HtmlTest < Test::Unit::TestCase
       parser.parse_body
       parser.general_output
     rescue Aozora2Html::Error => e
-      message = e.message.encode('utf-8')
+      message = e.message.to_utf8
     ensure
       $stdout = STDOUT
       assert_equal "エラー(0行目):字下げ中に本文が終了しました. \r\n処理を停止します", message
@@ -280,7 +280,7 @@ class Aozora2HtmlTest < Test::Unit::TestCase
   end
 
   def test_ending_check
-    input = StringIO.new("本文\r\n\r\n底本：test\r\n".encode('shift_jis'))
+    input = StringIO.new("本文\r\n\r\n底本：test\r\n".to_sjis)
     output = StringIO.new
     parser = Aozora2Html.new(input, output)
     out = StringIO.new
@@ -293,7 +293,7 @@ class Aozora2HtmlTest < Test::Unit::TestCase
       parser.parse_body
       parser.parse_body
     rescue Aozora2Html::Error => e
-      _message = e.message.encode('utf-8')
+      _message = e.message.to_utf8
     ensure
       $stdout = STDOUT
       output.seek(0)
@@ -303,7 +303,7 @@ class Aozora2HtmlTest < Test::Unit::TestCase
   end
 
   def test_invalid_closing
-    input = StringIO.new("［＃ここで太字終わり］\r\n".encode('shift_jis'))
+    input = StringIO.new("［＃ここで太字終わり］\r\n".to_sjis)
     output = StringIO.new
     parser = Aozora2Html.new(input, output)
     out = StringIO.new
@@ -312,7 +312,7 @@ class Aozora2HtmlTest < Test::Unit::TestCase
     begin
       parser.parse_body
     rescue Aozora2Html::Error => e
-      message = e.message.encode('utf-8')
+      message = e.message.to_utf8
     ensure
       $stdout = STDOUT
       assert_equal "エラー(0行目):太字を閉じようとしましたが、太字中ではありません. \r\n処理を停止します", message
@@ -320,7 +320,7 @@ class Aozora2HtmlTest < Test::Unit::TestCase
   end
 
   def test_invalid_nest
-    input = StringIO.new("［＃太字］［＃傍線］あ［＃太字終わり］\r\n".encode('shift_jis'))
+    input = StringIO.new("［＃太字］［＃傍線］あ［＃太字終わり］\r\n".to_sjis)
     output = StringIO.new
     parser = Aozora2Html.new(input, output)
     out = StringIO.new
@@ -335,7 +335,7 @@ class Aozora2HtmlTest < Test::Unit::TestCase
       parser.parse_body
       parser.parse_body
     rescue Aozora2Html::Error => e
-      message = e.message.encode('utf-8')
+      message = e.message.to_utf8
     ensure
       $stdout = STDOUT
       assert_equal "エラー(0行目):太字を終了しようとしましたが、傍線中です. \r\n処理を停止します", message
@@ -343,7 +343,7 @@ class Aozora2HtmlTest < Test::Unit::TestCase
   end
 
   def test_command_do
-    input = StringIO.new("［＃ここから太字］\r\nテスト。\r\n［＃ここで太字終わり］\r\n".encode('shift_jis'))
+    input = StringIO.new("［＃ここから太字］\r\nテスト。\r\n［＃ここで太字終わり］\r\n".to_sjis)
     output = StringIO.new
     parser = Aozora2Html.new(input, output)
     out = StringIO.new
@@ -354,7 +354,7 @@ class Aozora2HtmlTest < Test::Unit::TestCase
         parser.parse_body
       end
     rescue Aozora2Html::Error => e
-      _message = e.message.encode('utf-8')
+      _message = e.message.to_utf8
     ensure
       $stdout = STDOUT
       output.seek(0)

--- a/test/test_aozora_accent_parser.rb
+++ b/test/test_aozora_accent_parser.rb
@@ -7,24 +7,26 @@ class Aozora2HtmlAccentParserTest < Test::Unit::TestCase
   def setup
   end
 
+  using Aozora2Html::StringRefinements
+
   def test_new
-    str = "〔e'tiquette〕\r\n".encode('shift_jis')
+    str = "〔e'tiquette〕\r\n".to_sjis
     strio = StringIO.new(str)
     stream = Jstream.new(strio)
-    parsed = Aozora2Html::AccentParser.new(stream, '〕'.encode('shift_jis'), {}, [], gaiji_dir: 'g_dir/').process
+    parsed = Aozora2Html::AccentParser.new(stream, '〕'.to_sjis, {}, [], gaiji_dir: 'g_dir/').process
     expected = '〔<img src="g_dir/1-09/1-09-63.png" alt="※(アキュートアクセント付きE小文字)" class="gaiji" />tiquette'
-    assert_equal expected, parsed.to_s.encode('utf-8')
+    assert_equal expected, parsed.to_s.to_utf8
   end
 
   def test_invalid
-    str = "〔e'tiquette\r\n".encode('shift_jis')
+    str = "〔e'tiquette\r\n".to_sjis
     strio = StringIO.new(str)
     stream = Jstream.new(strio)
     $stdout = StringIO.new
     begin
-      _parsed = Aozora2Html::AccentParser.new(stream, '〕'.encode('shift_jis'), {}, [], gaiji_dir: 'g_dir/').process
+      _parsed = Aozora2Html::AccentParser.new(stream, '〕'.to_sjis, {}, [], gaiji_dir: 'g_dir/').process
       out_str = $stdout.string
-      assert_equal "警告(1行目):アクセント分解の亀甲括弧の始めと終わりが、行中で揃っていません\n", out_str.encode('utf-8')
+      assert_equal "警告(1行目):アクセント分解の亀甲括弧の始めと終わりが、行中で揃っていません\n", out_str.to_utf8
     ensure
       $stdout = STDOUT
     end
@@ -32,12 +34,12 @@ class Aozora2HtmlAccentParserTest < Test::Unit::TestCase
 
   def test_use_jisx0213
     Aozora2Html::Tag::Accent.use_jisx0213 = true
-    str = "〔e'tiquette〕\r\n".encode('shift_jis')
+    str = "〔e'tiquette〕\r\n".to_sjis
     strio = StringIO.new(str)
     stream = Jstream.new(strio)
-    parsed = Aozora2Html::AccentParser.new(stream, '〕'.encode('shift_jis'), {}, [], gaiji_dir: 'g_dir/').process
+    parsed = Aozora2Html::AccentParser.new(stream, '〕'.to_sjis, {}, [], gaiji_dir: 'g_dir/').process
     expected = '〔&#x00E9;tiquette'
-    assert_equal expected, parsed.to_s.encode('utf-8')
+    assert_equal expected, parsed.to_s.to_utf8
   end
 
   def teardown

--- a/test/test_command_parse.rb
+++ b/test/test_command_parse.rb
@@ -194,8 +194,10 @@ class CommandParseTest < Test::Unit::TestCase
     assert_equal expected, parsed
   end
 
+  using Aozora2Html::StringRefinements
+
   def parse_text(input_text)
-    input = StringIO.new(input_text.encode('shift_jis'))
+    input = StringIO.new(input_text.to_sjis)
     output = StringIO.new
     parser = Aozora2Html.new(input, output)
     parser.instance_eval { @section = :tail }
@@ -204,7 +206,7 @@ class CommandParseTest < Test::Unit::TestCase
         parser.parse
       end
     end
-    output.string.encode('utf-8')
+    output.string.to_utf8
   end
 
   def teardown

--- a/test/test_dakuten_katakana_tag.rb
+++ b/test/test_dakuten_katakana_tag.rb
@@ -10,14 +10,16 @@ class DakutenKatakanaTagTest < Test::Unit::TestCase
     stub(@parser).block_allowed_context? { true }
   end
 
+  using Aozora2Html::StringRefinements
+
   def test_dakuten_katakana_new
-    tag = Aozora2Html::Tag::DakutenKatakana.new(@parser, 1, 'ア'.encode('shift_jis'), gaiji_dir: @gaiji_dir)
+    tag = Aozora2Html::Tag::DakutenKatakana.new(@parser, 1, 'ア'.to_sjis, gaiji_dir: @gaiji_dir)
     assert_equal Aozora2Html::Tag::DakutenKatakana, tag.class
     assert_equal true, tag.is_a?(Aozora2Html::Tag::Inline)
   end
 
   def test_to_s
-    tag = Aozora2Html::Tag::DakutenKatakana.new(@parser, 1, 'ア'.encode('shift_jis'), gaiji_dir: @gaiji_dir)
-    assert_equal '<img src="g_dir/1-07/1-07-81.png" alt="※(濁点付き片仮名「ア」、1-07-81)" class="gaiji" />', tag.to_s.encode('utf-8')
+    tag = Aozora2Html::Tag::DakutenKatakana.new(@parser, 1, 'ア'.to_sjis, gaiji_dir: @gaiji_dir)
+    assert_equal '<img src="g_dir/1-07/1-07-81.png" alt="※(濁点付き片仮名「ア」、1-07-81)" class="gaiji" />', tag.to_s.to_utf8
   end
 end

--- a/test/test_decorate_tag.rb
+++ b/test/test_decorate_tag.rb
@@ -15,9 +15,11 @@ class DecorateTagTest < Test::Unit::TestCase
     assert_equal true, tag.is_a?(Aozora2Html::Tag::Inline)
   end
 
+  using Aozora2Html::StringRefinements
+
   def test_to_s
-    tag = Aozora2Html::Tag::Decorate.new(@parser, 'テスト'.encode('shift_jis'), 'foo', 'span')
-    assert_equal '<span class="foo">テスト</span>', tag.to_s.encode('utf-8')
+    tag = Aozora2Html::Tag::Decorate.new(@parser, 'テスト'.to_sjis, 'foo', 'span')
+    assert_equal '<span class="foo">テスト</span>', tag.to_s.to_utf8
   end
 
   def teardown

--- a/test/test_dir_tag.rb
+++ b/test/test_dir_tag.rb
@@ -9,15 +9,17 @@ class DirTagTest < Test::Unit::TestCase
     stub(@parser).block_allowed_context? { true }
   end
 
+  using Aozora2Html::StringRefinements
+
   def test_dir_new
-    tag = Aozora2Html::Tag::Dir.new(@parser, 'テスト'.encode('shift_jis'))
+    tag = Aozora2Html::Tag::Dir.new(@parser, 'テスト'.to_sjis)
     assert_equal Aozora2Html::Tag::Dir, tag.class
     assert_equal true, tag.is_a?(Aozora2Html::Tag::Inline)
   end
 
   def test_to_s
-    tag = Aozora2Html::Tag::Dir.new(@parser, 'テスト'.encode('shift_jis'))
-    assert_equal '<span dir="ltr">テスト</span>', tag.to_s.encode('utf-8')
+    tag = Aozora2Html::Tag::Dir.new(@parser, 'テスト'.to_sjis)
+    assert_equal '<span dir="ltr">テスト</span>', tag.to_s.to_utf8
   end
 
   def teardown

--- a/test/test_editor_note_tag.rb
+++ b/test/test_editor_note_tag.rb
@@ -7,15 +7,17 @@ class EditorNoteTagTest < Test::Unit::TestCase
   def setup
   end
 
+  using Aozora2Html::StringRefinements
+
   def test_editor_note_new
-    tag = Aozora2Html::Tag::EditorNote.new(nil, '注記のテスト'.encode('shift_jis'))
+    tag = Aozora2Html::Tag::EditorNote.new(nil, '注記のテスト'.to_sjis)
     assert_equal Aozora2Html::Tag::EditorNote, tag.class
     assert_equal true, tag.is_a?(Aozora2Html::Tag::Inline)
   end
 
   def test_to_s
-    tag = Aozora2Html::Tag::EditorNote.new(nil, '注記のテスト'.encode('shift_jis'))
-    assert_equal '<span class="notes">［＃注記のテスト］</span>', tag.to_s.encode('utf-8')
+    tag = Aozora2Html::Tag::EditorNote.new(nil, '注記のテスト'.to_sjis)
+    assert_equal '<span class="notes">［＃注記のテスト］</span>', tag.to_s.to_utf8
   end
 
   def teardown

--- a/test/test_exception.rb
+++ b/test/test_exception.rb
@@ -10,6 +10,8 @@ class ExceptionTest < Test::Unit::TestCase
     end
   end
 
+  using Aozora2Html::StringRefinements
+
   def test_raise_aozora_error
     error_msg = ''
     begin
@@ -18,6 +20,6 @@ class ExceptionTest < Test::Unit::TestCase
       error_msg = e.message(123)
     end
     assert_equal "エラー(123行目):sample error. \r\n処理を停止します",
-                 error_msg.encode('utf-8')
+                 error_msg.to_utf8
   end
 end

--- a/test/test_font_size_tag.rb
+++ b/test/test_font_size_tag.rb
@@ -16,22 +16,22 @@ class FontSizeTagTest < Test::Unit::TestCase
     assert_equal true, tag.is_a?(Aozora2Html::Tag::Multiline)
   end
 
+  using Aozora2Html::StringRefinements
+
   def test_to_s
     tag = Aozora2Html::Tag::FontSize.new(@parser, 1, :dai)
-    assert_equal '<div class="dai1" style="font-size: large;">', tag.to_s.encode('utf-8')
+    assert_equal '<div class="dai1" style="font-size: large;">', tag.to_s.to_utf8
   end
 
   def test_to_s2
     tag = Aozora2Html::Tag::FontSize.new(@parser, 2, :dai)
-    assert_equal '<div class="dai2" style="font-size: x-large;">', tag.to_s.encode('utf-8')
+    assert_equal '<div class="dai2" style="font-size: x-large;">', tag.to_s.to_utf8
   end
 
   def test_to_s3
     tag = Aozora2Html::Tag::FontSize.new(@parser, 3, :sho)
-    assert_equal '<div class="sho3" style="font-size: xx-small;">', tag.to_s.encode('utf-8')
+    assert_equal '<div class="sho3" style="font-size: xx-small;">', tag.to_s.to_utf8
   end
-
-  using Aozora2Html::StringRefinements
 
   def test_to_s0
     assert_raise(Aozora2Html::Error.new('文字サイズの指定が不正です'.to_sjis)) do

--- a/test/test_gaiji_tag.rb
+++ b/test/test_gaiji_tag.rb
@@ -8,23 +8,25 @@ class EmbedGaijiTagTest < Test::Unit::TestCase
     @gaiji_dir = 'g_dir/'
   end
 
+  using Aozora2Html::StringRefinements
+
   def test_gaiji_new
     egt = Aozora2Html::Tag::EmbedGaiji.new(nil, 'foo', '1-2-3', 'name', gaiji_dir: @gaiji_dir)
-    assert_equal '<img src="g_dir/foo/1-2-3.png" alt="※(name)" class="gaiji" />', egt.to_s.encode('utf-8')
+    assert_equal '<img src="g_dir/foo/1-2-3.png" alt="※(name)" class="gaiji" />', egt.to_s.to_utf8
   end
 
   def test_unembed_gaiji_new
-    egt = Aozora2Html::Tag::UnEmbedGaiji.new(nil, 'テストtest'.encode('Shift_JIS'))
-    assert_equal '<span class="notes">［テストtest］</span>', egt.to_s.encode('utf-8')
+    egt = Aozora2Html::Tag::UnEmbedGaiji.new(nil, 'テストtest'.to_sjis)
+    assert_equal '<span class="notes">［テストtest］</span>', egt.to_s.to_utf8
   end
 
   def test_espcaed?
-    egt = Aozora2Html::Tag::UnEmbedGaiji.new(nil, 'テストtest'.encode('Shift_JIS'))
+    egt = Aozora2Html::Tag::UnEmbedGaiji.new(nil, 'テストtest'.to_sjis)
     assert_equal false, egt.escaped?
   end
 
   def test_espcae!
-    egt = Aozora2Html::Tag::UnEmbedGaiji.new(nil, 'テストtest'.encode('Shift_JIS'))
+    egt = Aozora2Html::Tag::UnEmbedGaiji.new(nil, 'テストtest'.to_sjis)
     egt.escape!
     assert_equal true, egt.escaped?
   end
@@ -32,13 +34,13 @@ class EmbedGaijiTagTest < Test::Unit::TestCase
   def test_jisx0213
     Aozora2Html::Tag::EmbedGaiji.use_jisx0213 = true
     egt = Aozora2Html::Tag::EmbedGaiji.new(nil, 'foo', '1-06-75', 'snowman', gaiji_dir: @gaiji_dir)
-    assert_equal '&#x2603;', egt.to_s.encode('utf-8')
+    assert_equal '&#x2603;', egt.to_s.to_utf8
   end
 
   def test_use_unicode
     Aozora2Html::Tag::EmbedGaiji.use_unicode = true
     egt = Aozora2Html::Tag::EmbedGaiji.new(nil, 'foo', '1-06-75', 'snowman', '2603', gaiji_dir: @gaiji_dir)
-    assert_equal '&#x2603;', egt.to_s.encode('utf-8')
+    assert_equal '&#x2603;', egt.to_s.to_utf8
   end
 
   def teardown

--- a/test/test_header.rb
+++ b/test/test_header.rb
@@ -8,10 +8,12 @@ class HeaderTest < Test::Unit::TestCase
     @header = Aozora2Html::Header.new(css_files: Array['../../aozora.css'])
   end
 
+  using Aozora2Html::StringRefinements
+
   def test_header_to_html
-    @header.push('武装せる市街'.encode('shift_jis'))
-    @header.push('黒島伝治'.encode('shift_jis'))
-    actual = @header.to_html.encode('utf-8')
+    @header.push('武装せる市街'.to_sjis)
+    @header.push('黒島伝治'.to_sjis)
+    actual = @header.to_html.to_utf8
 
     # rubocop:disable Layout/LineLength
     expected =
@@ -22,21 +24,21 @@ class HeaderTest < Test::Unit::TestCase
   end
 
   def test_build_title
-    @header.push('武装せる市街'.encode('shift_jis'))
-    @header.push('黒島伝治'.encode('shift_jis'))
+    @header.push('武装せる市街'.to_sjis)
+    @header.push('黒島伝治'.to_sjis)
     header_info = @header.build_header_info
-    actual = @header.build_title(header_info).encode('utf-8')
+    actual = @header.build_title(header_info).to_utf8
     expected = '<title>黒島伝治 武装せる市街</title>'
     assert_equal(expected, actual)
   end
 
   def test_build_title2
-    @header.push('スリーピー・ホローの伝説'.encode('shift_jis'))
-    @header.push('故ディードリッヒ・ニッカボッカーの遺稿より'.encode('shift_jis'))
-    @header.push('ワシントン・アーヴィング　Washington Irving'.encode('shift_jis'))
-    @header.push('吉田甲子太郎訳'.encode('shift_jis'))
+    @header.push('スリーピー・ホローの伝説'.to_sjis)
+    @header.push('故ディードリッヒ・ニッカボッカーの遺稿より'.to_sjis)
+    @header.push('ワシントン・アーヴィング　Washington Irving'.to_sjis)
+    @header.push('吉田甲子太郎訳'.to_sjis)
     header_info = @header.build_header_info
-    actual = @header.build_title(header_info).encode('utf-8')
+    actual = @header.build_title(header_info).to_utf8
     expected = '<title>ワシントン・アーヴィング　Washington Irving 吉田甲子太郎訳 スリーピー・ホローの伝説 故ディードリッヒ・ニッカボッカーの遺稿より</title>'
     assert_equal(expected, actual)
   end

--- a/test/test_i18n.rb
+++ b/test/test_i18n.rb
@@ -4,12 +4,14 @@ require 'test_helper'
 require 'aozora2html'
 
 class I18nTest < Test::Unit::TestCase
+  using Aozora2Html::StringRefinements
+
   def test_t
     assert_equal '警告(123行目):JIS外字「①」が使われています',
                  Aozora2Html::I18n.t(:warn_jis_gaiji,
                                      123,
                                      '①'.encode('cp932').force_encoding('shift_jis'))
-                                  .force_encoding('cp932').encode('utf-8')
+                                  .force_encoding('cp932').to_utf8
   end
 
   def test_error_utf8
@@ -29,7 +31,7 @@ class I18nTest < Test::Unit::TestCase
     $stdout = StringIO.new
     begin
       puts '①'.encode('cp932').force_encoding('shift_jis')
-      assert_equal "①\n", $stdout.string.force_encoding('cp932').encode('utf-8')
+      assert_equal "①\n", $stdout.string.force_encoding('cp932').to_utf8
     ensure
       $stdout = STDOUT
     end

--- a/test/test_img_tag.rb
+++ b/test/test_img_tag.rb
@@ -15,9 +15,11 @@ class ImgTagTest < Test::Unit::TestCase
     assert_equal true, tag.is_a?(Aozora2Html::Tag::Inline)
   end
 
+  using Aozora2Html::StringRefinements
+
   def test_to_s
     tag = Aozora2Html::Tag::Img.new(@parser, 'foo.png', 'img1', 'alt img1', 40, 50)
-    assert_equal '<img class="img1" width="40" height="50" src="foo.png" alt="alt img1" />', tag.to_s.encode('utf-8')
+    assert_equal '<img class="img1" width="40" height="50" src="foo.png" alt="alt img1" />', tag.to_s.to_utf8
   end
 
   def teardown

--- a/test/test_inline_caption_tag.rb
+++ b/test/test_inline_caption_tag.rb
@@ -15,9 +15,11 @@ class InlineCaptionTagTest < Test::Unit::TestCase
     assert_equal true, tag.is_a?(Aozora2Html::Tag::Inline)
   end
 
+  using Aozora2Html::StringRefinements
+
   def test_to_s
-    tag = Aozora2Html::Tag::InlineCaption.new(@parser, 'テスト'.encode('shift_jis'))
-    assert_equal '<span class="caption">テスト</span>', tag.to_s.encode('utf-8')
+    tag = Aozora2Html::Tag::InlineCaption.new(@parser, 'テスト'.to_sjis)
+    assert_equal '<span class="caption">テスト</span>', tag.to_s.to_utf8
   end
 
   def teardown

--- a/test/test_inline_font_size_tag.rb
+++ b/test/test_inline_font_size_tag.rb
@@ -15,19 +15,21 @@ class InlineFontSizeTagTest < Test::Unit::TestCase
     assert_equal true, tag.is_a?(Aozora2Html::Tag::Inline)
   end
 
+  using Aozora2Html::StringRefinements
+
   def test_to_s
-    tag = Aozora2Html::Tag::InlineFontSize.new(@parser, 'テスト'.encode('shift_jis'), 1, :dai)
-    assert_equal '<span class="dai1" style="font-size: large;">テスト</span>', tag.to_s.encode('utf-8')
+    tag = Aozora2Html::Tag::InlineFontSize.new(@parser, 'テスト'.to_sjis, 1, :dai)
+    assert_equal '<span class="dai1" style="font-size: large;">テスト</span>', tag.to_s.to_utf8
   end
 
   def test_to_s2
-    tag = Aozora2Html::Tag::InlineFontSize.new(@parser, 'テスト'.encode('shift_jis'), 2, :sho)
-    assert_equal '<span class="sho2" style="font-size: x-small;">テスト</span>', tag.to_s.encode('utf-8')
+    tag = Aozora2Html::Tag::InlineFontSize.new(@parser, 'テスト'.to_sjis, 2, :sho)
+    assert_equal '<span class="sho2" style="font-size: x-small;">テスト</span>', tag.to_s.to_utf8
   end
 
   def test_to_s3
-    tag = Aozora2Html::Tag::InlineFontSize.new(@parser, 'テスト'.encode('shift_jis'), 3, :sho)
-    assert_equal '<span class="sho3" style="font-size: xx-small;">テスト</span>', tag.to_s.encode('utf-8')
+    tag = Aozora2Html::Tag::InlineFontSize.new(@parser, 'テスト'.to_sjis, 3, :sho)
+    assert_equal '<span class="sho3" style="font-size: xx-small;">テスト</span>', tag.to_s.to_utf8
   end
 
   def teardown

--- a/test/test_inline_keigakomi_tag.rb
+++ b/test/test_inline_keigakomi_tag.rb
@@ -15,9 +15,11 @@ class InlineKeigakomiTagTest < Test::Unit::TestCase
     assert_equal true, tag.is_a?(Aozora2Html::Tag::Inline)
   end
 
+  using Aozora2Html::StringRefinements
+
   def test_to_s
-    tag = Aozora2Html::Tag::InlineKeigakomi.new(@parser, 'テスト'.encode('shift_jis'))
-    assert_equal '<span class="keigakomi">テスト</span>', tag.to_s.encode('utf-8')
+    tag = Aozora2Html::Tag::InlineKeigakomi.new(@parser, 'テスト'.to_sjis)
+    assert_equal '<span class="keigakomi">テスト</span>', tag.to_s.to_utf8
   end
 
   def teardown

--- a/test/test_inline_yokogumi_tag.rb
+++ b/test/test_inline_yokogumi_tag.rb
@@ -15,9 +15,11 @@ class InlineYokogumiTagTest < Test::Unit::TestCase
     assert_equal true, tag.is_a?(Aozora2Html::Tag::Inline)
   end
 
+  using Aozora2Html::StringRefinements
+
   def test_to_s
-    tag = Aozora2Html::Tag::InlineYokogumi.new(@parser, 'テスト'.encode('shift_jis'))
-    assert_equal '<span class="yokogumi">テスト</span>', tag.to_s.encode('utf-8')
+    tag = Aozora2Html::Tag::InlineYokogumi.new(@parser, 'テスト'.to_sjis)
+    assert_equal '<span class="yokogumi">テスト</span>', tag.to_s.to_utf8
   end
 
   def teardown

--- a/test/test_jstream.rb
+++ b/test/test_jstream.rb
@@ -5,6 +5,8 @@ require 'aozora2html'
 require 'stringio'
 
 class JstreamTest < Test::Unit::TestCase
+  using Aozora2Html::StringRefinements
+
   def test_new_error
     strio = StringIO.new("aaa\nbbb\n")
     orig_stdout = $stdout
@@ -14,45 +16,45 @@ class JstreamTest < Test::Unit::TestCase
       Jstream.new(strio)
     end
     $stdout = orig_stdout
-    assert_equal "エラー(1行目):改行コードを、「CR+LF」にあらためてください. \r\n処理を停止します\n", out.string.encode('utf-8')
+    assert_equal "エラー(1行目):改行コードを、「CR+LF」にあらためてください. \r\n処理を停止します\n", out.string.to_utf8
   end
 
   def test_read_char
-    strio = StringIO.new("aあ５\r\n％\\b\r\n".encode('Shift_JIS'))
+    strio = StringIO.new("aあ５\r\n％\\b\r\n".to_sjis)
     stm = Jstream.new(strio)
-    assert_equal 'a', stm.read_char.encode('utf-8')
-    assert_equal 'あ', stm.read_char.encode('utf-8')
-    assert_equal '５', stm.read_char.encode('utf-8')
-    assert_equal "\r\n", stm.read_char.encode('utf-8')
-    assert_equal '％', stm.read_char.encode('utf-8')
-    assert_equal '\\', stm.read_char.encode('utf-8')
-    assert_equal 'b', stm.read_char.encode('utf-8')
-    assert_equal "\r\n", stm.read_char.encode('utf-8')
+    assert_equal 'a', stm.read_char.to_utf8
+    assert_equal 'あ', stm.read_char.to_utf8
+    assert_equal '５', stm.read_char.to_utf8
+    assert_equal "\r\n", stm.read_char.to_utf8
+    assert_equal '％', stm.read_char.to_utf8
+    assert_equal '\\', stm.read_char.to_utf8
+    assert_equal 'b', stm.read_char.to_utf8
+    assert_equal "\r\n", stm.read_char.to_utf8
     assert_equal :eof, stm.read_char
     # assert_equal "\r\n", stm.read_char  # :eof以降は正しい値を保証しない
     assert_equal :eof, stm.read_char # 何度もread_charすると:eofが複数回出る
   end
 
   def test_peek_char
-    strio = StringIO.new("aあ５\r\n％\\b\r\n".encode('Shift_JIS'))
+    strio = StringIO.new("aあ５\r\n％\\b\r\n".to_sjis)
     stm = Jstream.new(strio)
-    assert_equal 'a', stm.peek_char(0).encode('utf-8')
-    assert_equal 'あ', stm.peek_char(1).encode('utf-8')
-    assert_equal '５', stm.peek_char(2).encode('utf-8')
-    assert_equal "\r\n", stm.peek_char(3).encode('utf-8')
-    # assert_equal "\r\n", stm.peek_char(4).encode('utf-8') # 改行文字以降は正しい値を保証しない
-    # assert_equal "\r\n", stm.peek_char(5).encode('utf-8') # 同上
-    # assert_equal "\r\n", stm.peek_char(100).encode('utf-8') # 同上
-    assert_equal 'a', stm.read_char.encode('utf-8')
+    assert_equal 'a', stm.peek_char(0).to_utf8
+    assert_equal 'あ', stm.peek_char(1).to_utf8
+    assert_equal '５', stm.peek_char(2).to_utf8
+    assert_equal "\r\n", stm.peek_char(3).to_utf8
+    # assert_equal "\r\n", stm.peek_char(4).to_utf8 # 改行文字以降は正しい値を保証しない
+    # assert_equal "\r\n", stm.peek_char(5).to_utf8 # 同上
+    # assert_equal "\r\n", stm.peek_char(100).to_utf8 # 同上
+    assert_equal 'a', stm.read_char.to_utf8
 
-    assert_equal 'あ', stm.peek_char(0).encode('utf-8')
-    assert_equal 'あ', stm.read_char.encode('utf-8')
-    assert_equal '５', stm.read_char.encode('utf-8')
-    assert_equal "\r\n", stm.read_char.encode('utf-8')
+    assert_equal 'あ', stm.peek_char(0).to_utf8
+    assert_equal 'あ', stm.read_char.to_utf8
+    assert_equal '５', stm.read_char.to_utf8
+    assert_equal "\r\n", stm.read_char.to_utf8
 
-    assert_equal '％', stm.peek_char(0).encode('utf-8')
-    assert_equal '\\', stm.peek_char(1).encode('utf-8')
-    assert_equal 'b', stm.peek_char(2).encode('utf-8')
-    assert_equal "\r\n", stm.peek_char(3).encode('utf-8')
+    assert_equal '％', stm.peek_char(0).to_utf8
+    assert_equal '\\', stm.peek_char(1).to_utf8
+    assert_equal 'b', stm.peek_char(2).to_utf8
+    assert_equal "\r\n", stm.peek_char(3).to_utf8
   end
 end

--- a/test/test_kaeriten_tag.rb
+++ b/test/test_kaeriten_tag.rb
@@ -15,9 +15,11 @@ class KaeritenTagTest < Test::Unit::TestCase
     assert_equal true, tag.is_a?(Aozora2Html::Tag::Inline)
   end
 
+  using Aozora2Html::StringRefinements
+
   def test_to_s
-    tag = Aozora2Html::Tag::Kaeriten.new(@parser, 'テスト'.encode('shift_jis'))
-    assert_equal '<sub class="kaeriten">テスト</sub>', tag.to_s.encode('utf-8')
+    tag = Aozora2Html::Tag::Kaeriten.new(@parser, 'テスト'.to_sjis)
+    assert_equal '<sub class="kaeriten">テスト</sub>', tag.to_s.to_utf8
   end
 
   def teardown

--- a/test/test_midashi_tag.rb
+++ b/test/test_midashi_tag.rb
@@ -10,26 +10,28 @@ class MidashiTagTest < Test::Unit::TestCase
     stub(@parser).new_midashi_id { 2 }
   end
 
+  using Aozora2Html::StringRefinements
+
   def test_midashi_new
-    tag = Aozora2Html::Tag::Midashi.new(@parser, 'テスト見出し'.encode('shift_jis'), '小'.encode('shift_jis'), :normal)
+    tag = Aozora2Html::Tag::Midashi.new(@parser, 'テスト見出し'.to_sjis, '小'.to_sjis, :normal)
     assert_equal Aozora2Html::Tag::Midashi, tag.class
     assert_equal true, tag.is_a?(Aozora2Html::Tag::Inline)
   end
 
   def test_to_s
-    tag = Aozora2Html::Tag::Midashi.new(@parser, 'テスト見出し'.encode('shift_jis'), '小'.encode('shift_jis'), :normal)
-    assert_equal "<h5 class=\"ko-midashi\"><a class=\"midashi_anchor\" id=\"midashi2\">#{'テスト見出し'.encode('shift_jis')}</a></h5>", tag.to_s
+    tag = Aozora2Html::Tag::Midashi.new(@parser, 'テスト見出し'.to_sjis, '小'.to_sjis, :normal)
+    assert_equal "<h5 class=\"ko-midashi\"><a class=\"midashi_anchor\" id=\"midashi2\">#{'テスト見出し'.to_sjis}</a></h5>", tag.to_s
   end
 
   def test_to_s_mado
-    tag = Aozora2Html::Tag::Midashi.new(@parser, 'テスト見出し'.encode('shift_jis'), '小'.encode('shift_jis'), :mado)
-    assert_equal "<h5 class=\"mado-ko-midashi\"><a class=\"midashi_anchor\" id=\"midashi2\">#{'テスト見出し'.encode('shift_jis')}</a></h5>", tag.to_s
+    tag = Aozora2Html::Tag::Midashi.new(@parser, 'テスト見出し'.to_sjis, '小'.to_sjis, :mado)
+    assert_equal "<h5 class=\"mado-ko-midashi\"><a class=\"midashi_anchor\" id=\"midashi2\">#{'テスト見出し'.to_sjis}</a></h5>", tag.to_s
   end
 
   def test_undeined_midashi
-    Aozora2Html::Tag::Midashi.new(@parser, 'テスト見出し'.encode('shift_jis'), 'あ'.encode('shift_jis'), :normal)
+    Aozora2Html::Tag::Midashi.new(@parser, 'テスト見出し'.to_sjis, 'あ'.to_sjis, :normal)
   rescue Aozora2Html::Error => e
-    assert_equal e.message(123).encode('utf-8'), "エラー(123行目):未定義な見出しです. \r\n処理を停止します"
+    assert_equal e.message(123).to_utf8, "エラー(123行目):未定義な見出しです. \r\n処理を停止します"
   end
 
   def teardown

--- a/test/test_multiline_midashi_tag.rb
+++ b/test/test_multiline_midashi_tag.rb
@@ -10,41 +10,43 @@ class MultilineMidashiTagTest < Test::Unit::TestCase
     stub(@parser).new_midashi_id { 2 }
   end
 
+  using Aozora2Html::StringRefinements
+
   def test_multiline_midashi_new
-    tag = Aozora2Html::Tag::MultilineMidashi.new(@parser, '小'.encode('shift_jis'), :normal)
+    tag = Aozora2Html::Tag::MultilineMidashi.new(@parser, '小'.to_sjis, :normal)
     assert_equal Aozora2Html::Tag::MultilineMidashi, tag.class
     assert_equal true, tag.is_a?(Aozora2Html::Tag::Block)
     assert_equal true, tag.is_a?(Aozora2Html::Tag::Multiline)
   end
 
   def test_to_s
-    tag = Aozora2Html::Tag::MultilineMidashi.new(@parser, '小'.encode('shift_jis'), :normal)
+    tag = Aozora2Html::Tag::MultilineMidashi.new(@parser, '小'.to_sjis, :normal)
     assert_equal '<h5 class="ko-midashi"><a class="midashi_anchor" id="midashi2">', tag.to_s
     assert_equal '</a></h5>', tag.close_tag
   end
 
   def test_to_s_chu
-    tag = Aozora2Html::Tag::MultilineMidashi.new(@parser, '中'.encode('shift_jis'), :dogyo)
+    tag = Aozora2Html::Tag::MultilineMidashi.new(@parser, '中'.to_sjis, :dogyo)
     assert_equal '<h4 class="dogyo-naka-midashi"><a class="midashi_anchor" id="midashi2">', tag.to_s
     assert_equal '</a></h4>', tag.close_tag
   end
 
   def test_to_s_dai
-    tag = Aozora2Html::Tag::MultilineMidashi.new(@parser, '大'.encode('shift_jis'), :mado)
+    tag = Aozora2Html::Tag::MultilineMidashi.new(@parser, '大'.to_sjis, :mado)
     assert_equal '<h3 class="mado-o-midashi"><a class="midashi_anchor" id="midashi2">', tag.to_s
     assert_equal '</a></h3>', tag.close_tag
   end
 
   def test_undeined_midashi
-    Aozora2Html::Tag::MultilineMidashi.new(@parser, 'あ'.encode('shift_jis'), :mado)
+    Aozora2Html::Tag::MultilineMidashi.new(@parser, 'あ'.to_sjis, :mado)
   rescue Aozora2Html::Error => e
-    assert_equal e.message(123).encode('utf-8'), "エラー(123行目):未定義な見出しです. \r\n処理を停止します"
+    assert_equal e.message(123).to_utf8, "エラー(123行目):未定義な見出しです. \r\n処理を停止します"
   end
 
   def test_undeined_midashi2
-    Aozora2Html::Tag::MultilineMidashi.new(@parser, '大'.encode('shift_jis'), :madoo)
+    Aozora2Html::Tag::MultilineMidashi.new(@parser, '大'.to_sjis, :madoo)
   rescue Aozora2Html::Error => e
-    assert_equal e.message(123).encode('utf-8'), "エラー(123行目):未定義な見出しです. \r\n処理を停止します"
+    assert_equal e.message(123).to_utf8, "エラー(123行目):未定義な見出しです. \r\n処理を停止します"
   end
 
   def teardown

--- a/test/test_okurigana_tag.rb
+++ b/test/test_okurigana_tag.rb
@@ -15,9 +15,11 @@ class OkuriganaTagTest < Test::Unit::TestCase
     assert_equal true, tag.is_a?(Aozora2Html::Tag::Inline)
   end
 
+  using Aozora2Html::StringRefinements
+
   def test_to_s
-    tag = Aozora2Html::Tag::Okurigana.new(@parser, 'テスト'.encode('shift_jis'))
-    assert_equal '<sup class="okurigana">テスト</sup>', tag.to_s.encode('utf-8')
+    tag = Aozora2Html::Tag::Okurigana.new(@parser, 'テスト'.to_sjis)
+    assert_equal '<sup class="okurigana">テスト</sup>', tag.to_s.to_utf8
   end
 
   def teardown

--- a/test/test_ruby_parse.rb
+++ b/test/test_ruby_parse.rb
@@ -98,9 +98,11 @@ class RubyParseTest < Test::Unit::TestCase
     assert_equal expected, parsed
   end
 
+  using Aozora2Html::StringRefinements
+
   def test_parse_ruby12
     src = "大空文庫《あおぞらぶんこ》［＃「大空文庫」に「ママ」の注記］\r\n"
-    assert_raise(Aozora2Html::Error.new('同じ箇所に2つのルビはつけられません'.encode('shift_jis'))) do
+    assert_raise(Aozora2Html::Error.new('同じ箇所に2つのルビはつけられません'.to_sjis)) do
       _parsed = parse_text(src)
     end
   end
@@ -113,7 +115,7 @@ class RubyParseTest < Test::Unit::TestCase
   end
 
   def parse_text(input_text)
-    input = StringIO.new(input_text.encode('shift_jis'))
+    input = StringIO.new(input_text.to_sjis)
     output = StringIO.new
     parser = Aozora2Html.new(input, output)
     parser.instance_eval { @section = :tail }
@@ -123,6 +125,6 @@ class RubyParseTest < Test::Unit::TestCase
       end
     end
 
-    output.string.encode('utf-8')
+    output.string.to_utf8
   end
 end

--- a/test/test_ruby_tag.rb
+++ b/test/test_ruby_tag.rb
@@ -9,15 +9,17 @@ class RubyTagTest < Test::Unit::TestCase
     stub(@parser).block_allowed_context? { true }
   end
 
+  using Aozora2Html::StringRefinements
+
   def test_ruby_new
-    tag = Aozora2Html::Tag::Ruby.new(@parser, 'aaa'.encode('shift_jis'), 'bb')
+    tag = Aozora2Html::Tag::Ruby.new(@parser, 'aaa'.to_sjis, 'bb')
     assert_equal Aozora2Html::Tag::Ruby, tag.class
     assert_equal true, tag.is_a?(Aozora2Html::Tag::Inline)
   end
 
   def test_to_s
-    tag = Aozora2Html::Tag::Ruby.new(@parser, 'テスト'.encode('shift_jis'), 'てすと'.encode('shift_jis'))
-    assert_equal '<ruby><rb>テスト</rb><rp>（</rp><rt>てすと</rt><rp>）</rp></ruby>', tag.to_s.encode('utf-8')
+    tag = Aozora2Html::Tag::Ruby.new(@parser, 'テスト'.to_sjis, 'てすと'.to_sjis)
+    assert_equal '<ruby><rb>テスト</rb><rp>（</rp><rt>てすと</rt><rp>）</rp></ruby>', tag.to_s.to_utf8
   end
 
   def teardown

--- a/test/test_tag_parser.rb
+++ b/test/test_tag_parser.rb
@@ -10,68 +10,70 @@ class TagParserTest < Test::Unit::TestCase
     @jisx0213 = Aozora2Html::Tag::EmbedGaiji.use_jisx0213
   end
 
+  using Aozora2Html::StringRefinements
+
   def test_parse_katakana
-    str = "テスト！あいうえお\r\n".encode('shift_jis')
+    str = "テスト！あいうえお\r\n".to_sjis
     strio = StringIO.new(str)
     stream = Jstream.new(strio)
-    command, _raw = Aozora2Html::TagParser.new(stream, '！'.encode('shift_jis'), {}, [], gaiji_dir: nil).process
+    command, _raw = Aozora2Html::TagParser.new(stream, '！'.to_sjis, {}, [], gaiji_dir: nil).process
     expected = 'テスト'
-    assert_equal expected, command.to_s.encode('utf-8')
+    assert_equal expected, command.to_s.to_utf8
   end
 
   def test_parse_bouten
-    str = "腹がへっても［＃「腹がへっても」に傍点］、ひもじゅうない［＃「ひもじゅうない」に傍点］とかぶりを振っている…\r\n".encode('shift_jis')
+    str = "腹がへっても［＃「腹がへっても」に傍点］、ひもじゅうない［＃「ひもじゅうない」に傍点］とかぶりを振っている…\r\n".to_sjis
     strio = StringIO.new(str)
     stream = Jstream.new(strio)
-    command, _raw = Aozora2Html::TagParser.new(stream, '…'.encode('shift_jis'), {}, [], gaiji_dir: nil).process
+    command, _raw = Aozora2Html::TagParser.new(stream, '…'.to_sjis, {}, [], gaiji_dir: nil).process
     expected = '<em class="sesame_dot">腹がへっても</em>、<em class="sesame_dot">ひもじゅうない</em>とかぶりを振っている'
-    assert_equal expected, command.to_s.encode('utf-8')
+    assert_equal expected, command.to_s.to_utf8
   end
 
   def test_parse_gaiji
-    str = "※［＃「てへん＋劣」、第3水準1-84-77］…\r\n".encode('shift_jis')
+    str = "※［＃「てへん＋劣」、第3水準1-84-77］…\r\n".to_sjis
     strio = StringIO.new(str)
     stream = Jstream.new(strio)
-    command, _raw = Aozora2Html::TagParser.new(stream, '…'.encode('shift_jis'), {}, [], gaiji_dir: 'g_dir/').process
+    command, _raw = Aozora2Html::TagParser.new(stream, '…'.to_sjis, {}, [], gaiji_dir: 'g_dir/').process
     expected = '<img src="g_dir/1-84/1-84-77.png" alt="※(「てへん＋劣」、第3水準1-84-77)" class="gaiji" />'
-    assert_equal expected, command.to_s.encode('utf-8')
+    assert_equal expected, command.to_s.to_utf8
   end
 
   def test_parse_gaiji_a
-    str = "※［＃「口＋世」、ページ数-行数］…\r\n".encode('shift_jis')
+    str = "※［＃「口＋世」、ページ数-行数］…\r\n".to_sjis
     strio = StringIO.new(str)
     stream = Jstream.new(strio)
-    command, _raw = Aozora2Html::TagParser.new(stream, '…'.encode('shift_jis'), {}, [], gaiji_dir: 'g_dir/').process
+    command, _raw = Aozora2Html::TagParser.new(stream, '…'.to_sjis, {}, [], gaiji_dir: 'g_dir/').process
     expected = '※<span class="notes">［＃「口＋世」、ページ数-行数］</span>'
-    assert_equal expected, command.to_s.encode('utf-8')
+    assert_equal expected, command.to_s.to_utf8
   end
 
   def test_parse_gaiji_b
-    str = "※［＃二の字点、1-2-22］…\r\n".encode('shift_jis')
+    str = "※［＃二の字点、1-2-22］…\r\n".to_sjis
     strio = StringIO.new(str)
     stream = Jstream.new(strio)
-    command, _raw = Aozora2Html::TagParser.new(stream, '…'.encode('shift_jis'), {}, [], gaiji_dir: 'g_dir/').process
+    command, _raw = Aozora2Html::TagParser.new(stream, '…'.to_sjis, {}, [], gaiji_dir: 'g_dir/').process
     expected = '<img src="g_dir/1-02/1-02-22.png" alt="※(二の字点、1-2-22)" class="gaiji" />'
-    assert_equal expected, command.to_s.encode('utf-8')
+    assert_equal expected, command.to_s.to_utf8
   end
 
   def test_parse_gaiji_kaeri
-    str = "自［＃二］女王國［＃一］東度［＃レ］海千餘里。…\r\n".encode('shift_jis')
+    str = "自［＃二］女王國［＃一］東度［＃レ］海千餘里。…\r\n".to_sjis
     strio = StringIO.new(str)
     stream = Jstream.new(strio)
-    command, _raw = Aozora2Html::TagParser.new(stream, '…'.encode('shift_jis'), {}, [], gaiji_dir: 'g_dir/').process
+    command, _raw = Aozora2Html::TagParser.new(stream, '…'.to_sjis, {}, [], gaiji_dir: 'g_dir/').process
     expected = '自<sub class="kaeriten">二</sub>女王國<sub class="kaeriten">一</sub>東度<sub class="kaeriten">レ</sub>海千餘里。'
-    assert_equal expected, command.to_s.encode('utf-8')
+    assert_equal expected, command.to_s.to_utf8
   end
 
   def test_parse_gaiji_jisx0213
     Aozora2Html::Tag::EmbedGaiji.use_jisx0213 = true
-    str = "※［＃「てへん＋劣」、第3水準1-84-77］…\r\n".encode('shift_jis')
+    str = "※［＃「てへん＋劣」、第3水準1-84-77］…\r\n".to_sjis
     strio = StringIO.new(str)
     stream = Jstream.new(strio)
-    command, _raw = Aozora2Html::TagParser.new(stream, '…'.encode('shift_jis'), {}, [], gaiji_dir: 'g_dir/').process
+    command, _raw = Aozora2Html::TagParser.new(stream, '…'.to_sjis, {}, [], gaiji_dir: 'g_dir/').process
     expected = '&#x6318;'
-    assert_equal expected, command.to_s.encode('utf-8')
+    assert_equal expected, command.to_s.to_utf8
   end
 
   def teardown


### PR DESCRIPTION
メインとしてはより多くの箇所で `String#to_sjis` (`Aozora2Html::StringRefinements`) を使う変更です

* `Aozora2Html::StringRefinements` に `String#to_utf8` を追加し、 `encode('utf-8')` としていた部分を置き換えました
* `String#to_sjis` の実装を `encode(Encoding::Shift_JIS)` に変更しました