### PR TITLE
Update ruby.rb

### DIFF
--- a/lib/aozora2html/tag/ruby.rb
+++ b/lib/aozora2html/tag/ruby.rb
@@ -40,7 +40,7 @@ class Aozora2Html
                     else
                       under_ruby
                     end
-        if (new_upper.length > 1) && (new_under.length > 1)
+        if (new_upper.length >= 1) && (new_under.length >= 1)
           raise Aozora2Html::Error, I18n.t(:dont_allow_triple_ruby)
         end
 


### PR DESCRIPTION
自信ないですが、空配列のlengthは0なのでここは``(new_upper.length > 1)``ではなく``(new_upper.length >= 1)``の方が適切に思えます。
違っていたらすみません。