### PR TITLE
Fix `to_sjis`

### DIFF
--- a/lib/aozora2html.rb
+++ b/lib/aozora2html.rb
@@ -959,7 +959,7 @@ class Aozora2Html
       # special inline ruby
       @style_stack.pop
       _whole, ruby = encount.match(PAT_INLINE_RUBY).to_a
-      push_char('</rb><rp>（</rp><rt>'.to_sjis + ruby + '</rt><rp>）</rp></ruby>'.to_sjis)
+      push_char('</rb><rp>' + PAREN_BEGIN_MARK + '</rp><rt>' + ruby + '</rt><rp>' + PAREN_END_MARK + '</rp></ruby>')
     elsif @style_stack.last_command.match?(encount)
       push_char(@style_stack.pop[1])
     else
@@ -1276,7 +1276,7 @@ class Aozora2Html
     string = @buffer.join
     @buffer = TextBuffer.new
     string.gsub!('info@aozora.gr.jp', '<a href="mailto: info@aozora.gr.jp">info@aozora.gr.jp</a>')
-    string.gsub!('青空文庫（http://www.aozora.gr.jp/）'.to_sjis) { "<a href=\"http://www.aozora.gr.jp/\">#{$&}</a>" }
+    string.gsub!(AOZORABUNKO + PAREN_BEGIN_MARK + 'http://www.aozora.gr.jp/' + PAREN_END_MARK) { "<a href=\"http://www.aozora.gr.jp/\">#{$&}</a>" }
     if string.match?(%r{(<br />$|</p>$|</h\d>$|<div.*>$|</div>$|^<[^>]*>$)})
       @out.print string, "\r\n"
     else

--- a/lib/aozora2html.rb
+++ b/lib/aozora2html.rb
@@ -963,7 +963,7 @@ class Aozora2Html
       # special inline ruby
       @style_stack.pop
       _whole, ruby = encount.match(PAT_INLINE_RUBY).to_a
-      push_char('</rb><rp>' + PAREN_BEGIN_MARK + '</rp><rt>' + ruby + '</rt><rp>' + PAREN_END_MARK + '</rp></ruby>')
+      push_char('</rb><rp>' + PAREN_BEGIN_MARK + '</rp><rt>' + ruby + '</rt><rp>' + PAREN_END_MARK + '</rp></ruby>') # rubocop:disable Style/StringConcatenation
     elsif @style_stack.last_command.match?(encount)
       push_char(@style_stack.pop[1])
     else
@@ -1280,7 +1280,7 @@ class Aozora2Html
     string = @buffer.join
     @buffer = TextBuffer.new
     string.gsub!('info@aozora.gr.jp', '<a href="mailto: info@aozora.gr.jp">info@aozora.gr.jp</a>')
-    string.gsub!(AOZORABUNKO + PAREN_BEGIN_MARK + 'http://www.aozora.gr.jp/' + PAREN_END_MARK) { "<a href=\"http://www.aozora.gr.jp/\">#{$&}</a>" }
+    string.gsub!(AOZORABUNKO + PAREN_BEGIN_MARK + 'http://www.aozora.gr.jp/' + PAREN_END_MARK) { "<a href=\"http://www.aozora.gr.jp/\">#{$&}</a>" } # rubocop:disable Style/StringConcatenation
     if string.match?(%r{(<br />$|</p>$|</h\d>$|<div.*>$|</div>$|^<[^>]*>$)})
       @out.print string, "\r\n"
     else

--- a/lib/aozora2html.rb
+++ b/lib/aozora2html.rb
@@ -111,6 +111,10 @@ class Aozora2Html
   REGEX_HANKAKU = Regexp.new("[A-Za-z0-9#\\-\\&'\\,]".to_sjis)
   REGEX_KANJI = Regexp.new('[亜-熙々※仝〆〇ヶ]'.to_sjis)
 
+  KANJI_NUMS = '一二三四五六七八九〇'.to_sjis
+  KANJI_TEN = '十'.to_sjis
+  ZENKAKU_NUMS = '０１２３４５６７８９'.to_sjis
+
   DYNAMIC_CONTENTS = "<div id=\"card\">\r\n<hr />\r\n<br />\r\n<a href=\"JavaScript:goLibCard();\" id=\"goAZLibCard\">●図書カード</a><script type=\"text/javascript\" src=\"../../contents.js\"></script>\r\n<script type=\"text/javascript\" src=\"../../golibcard.js\"></script>\r\n</div>".to_sjis
 
   # KUNOJI = ["18e518f5"].pack("h*")

--- a/lib/aozora2html.rb
+++ b/lib/aozora2html.rb
@@ -111,7 +111,7 @@ class Aozora2Html
   REGEX_HANKAKU = Regexp.new("[A-Za-z0-9#\\-\\&'\\,]".to_sjis)
   REGEX_KANJI = Regexp.new('[亜-熙々※仝〆〇ヶ]'.to_sjis)
 
-  KANJI_NUMS = '一二三四五六七八九〇'.to_sjis
+  KANJI_NUMS = '〇一二三四五六七八九'.to_sjis
   KANJI_TEN = '十'.to_sjis
   ZENKAKU_NUMS = '０１２３４５６７８９'.to_sjis
 

--- a/lib/aozora2html/tag/editor_note.rb
+++ b/lib/aozora2html/tag/editor_note.rb
@@ -12,7 +12,7 @@ class Aozora2Html
       using StringRefinements
 
       def to_s
-        '<span class="notes">' + COMMAND_BEGIN + IGETA_MARK + @desc + COMMAND_END + '</span>'
+        '<span class="notes">' + COMMAND_BEGIN + IGETA_MARK + @desc + COMMAND_END + '</span>' # rubocop:disable Style/StringConcatenation
       end
     end
   end

--- a/lib/aozora2html/tag/editor_note.rb
+++ b/lib/aozora2html/tag/editor_note.rb
@@ -12,7 +12,7 @@ class Aozora2Html
       using StringRefinements
 
       def to_s
-        '<span class="notes">［＃'.to_sjis + @desc + '］</span>'.to_sjis
+        '<span class="notes">' + COMMAND_BEGIN + IGETA_MARK + @desc + COMMAND_END + '</span>'
       end
     end
   end

--- a/lib/aozora2html/tag/un_embed_gaiji.rb
+++ b/lib/aozora2html/tag/un_embed_gaiji.rb
@@ -15,7 +15,7 @@ class Aozora2Html
       using StringRefinements
 
       def to_s
-        '<span class="notes">' + COMMAND_BEGIN + @desc + COMMAND_END + '</span>'
+        '<span class="notes">' + COMMAND_BEGIN + @desc + COMMAND_END + '</span>' # rubocop:disable Style/StringConcatenation
       end
 
       def escaped?

--- a/lib/aozora2html/tag/un_embed_gaiji.rb
+++ b/lib/aozora2html/tag/un_embed_gaiji.rb
@@ -15,7 +15,7 @@ class Aozora2Html
       using StringRefinements
 
       def to_s
-        '<span class="notes">［'.to_sjis + @desc + '］</span>'.to_sjis
+        '<span class="notes">' + COMMAND_BEGIN + @desc + COMMAND_END + '</span>'
       end
 
       def escaped?

--- a/lib/aozora2html/utils.rb
+++ b/lib/aozora2html/utils.rb
@@ -5,10 +5,6 @@ class Aozora2Html
   module Utils
     using StringRefinements
 
-    KANJI_NUMS = '一二三四五六七八九〇'.to_sjis
-    KANJI_TEN = '十'.to_sjis
-    ZENKAKU_NUMS = '０-９'.to_sjis
-
     def create_font_size(times, daisho)
       size = case times
              when 1
@@ -80,7 +76,7 @@ class Aozora2Html
     module_function :create_midashi_class
 
     def convert_japanese_number(command)
-      tmp = command.tr(ZENKAKU_NUMS, '0-9')
+      tmp = command.tr(ZENKAKU_NUMS, '0123456789')
       tmp.tr!(KANJI_NUMS, '1234567890')
       tmp.gsub!(/(\d)#{KANJI_TEN}(\d)/o) { "#{$1}#{$2}" }
       tmp.gsub!(/(\d)#{KANJI_TEN}/o) { "#{$1}0" }

--- a/lib/aozora2html/utils.rb
+++ b/lib/aozora2html/utils.rb
@@ -77,7 +77,7 @@ class Aozora2Html
 
     def convert_japanese_number(command)
       tmp = command.tr(ZENKAKU_NUMS, '0123456789')
-      tmp.tr!(KANJI_NUMS, '1234567890')
+      tmp.tr!(KANJI_NUMS, '0123456789')
       tmp.gsub!(/(\d)#{KANJI_TEN}(\d)/o) { "#{$1}#{$2}" }
       tmp.gsub!(/(\d)#{KANJI_TEN}/o) { "#{$1}0" }
       tmp.gsub!(/#{KANJI_TEN}(\d)/o) { "1#{$1}" }

--- a/test/test_utils.rb
+++ b/test/test_utils.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require 'aozora2html'
+
+class UtilsTest < Test::Unit::TestCase
+  using Aozora2Html::StringRefinements
+
+  def setup
+  end
+
+  def test_create_font_size()
+    assert_equal('small', Aozora2Html::Utils.create_font_size(1, :sho))
+    assert_equal('large', Aozora2Html::Utils.create_font_size(1, :dai))
+    assert_equal('x-small', Aozora2Html::Utils.create_font_size(2, :sho))
+    assert_equal('x-large', Aozora2Html::Utils.create_font_size(2, :dai))
+    assert_equal('xx-small', Aozora2Html::Utils.create_font_size(3, :sho))
+    assert_equal('xx-small', Aozora2Html::Utils.create_font_size(4, :sho))
+    assert_raise(Aozora2Html::Error) { Aozora2Html::Utils.create_font_size(0, :sho) }
+  end
+
+  def test_create_midashi_tag()
+    assert_equal('h5', Aozora2Html::Utils.create_midashi_tag('小'.to_sjis))
+    assert_equal('h4', Aozora2Html::Utils.create_midashi_tag('中'.to_sjis))
+    assert_equal('h3', Aozora2Html::Utils.create_midashi_tag('大'.to_sjis))
+    assert_raise(Aozora2Html::Error) { Aozora2Html::Utils.create_midashi_tag('標準'.to_sjis) }
+  end
+
+  def test_convert_japanese_number()
+    assert_equal('1', Aozora2Html::Utils.convert_japanese_number('１'.to_sjis))
+    assert_equal('2', Aozora2Html::Utils.convert_japanese_number('２'.to_sjis))
+    assert_equal('8', Aozora2Html::Utils.convert_japanese_number('８'.to_sjis))
+    assert_equal('9', Aozora2Html::Utils.convert_japanese_number('９'.to_sjis))
+    assert_equal('10', Aozora2Html::Utils.convert_japanese_number('１０'.to_sjis))
+    assert_equal('11', Aozora2Html::Utils.convert_japanese_number('１１'.to_sjis))
+    assert_equal('1', Aozora2Html::Utils.convert_japanese_number('一'.to_sjis))
+    assert_equal('2', Aozora2Html::Utils.convert_japanese_number('二'.to_sjis))
+    assert_equal('8', Aozora2Html::Utils.convert_japanese_number('八'.to_sjis))
+    assert_equal('9', Aozora2Html::Utils.convert_japanese_number('九'.to_sjis))
+    assert_equal('10', Aozora2Html::Utils.convert_japanese_number('十'.to_sjis))
+    assert_equal('10', Aozora2Html::Utils.convert_japanese_number('一〇'.to_sjis))
+    assert_equal('11', Aozora2Html::Utils.convert_japanese_number('十一'.to_sjis))
+    assert_equal('11', Aozora2Html::Utils.convert_japanese_number('一一'.to_sjis))
+    assert_equal('13', Aozora2Html::Utils.convert_japanese_number('十三'.to_sjis))
+    assert_equal('19', Aozora2Html::Utils.convert_japanese_number('十九'.to_sjis))
+    assert_equal('20', Aozora2Html::Utils.convert_japanese_number('二十'.to_sjis))
+    assert_equal('24', Aozora2Html::Utils.convert_japanese_number('二十四'.to_sjis))
+    assert_equal('24', Aozora2Html::Utils.convert_japanese_number('二四'.to_sjis))
+  end
+end

--- a/test/test_utils.rb
+++ b/test/test_utils.rb
@@ -9,7 +9,7 @@ class UtilsTest < Test::Unit::TestCase
   def setup
   end
 
-  def test_create_font_size()
+  def test_create_font_size
     assert_equal('small', Aozora2Html::Utils.create_font_size(1, :sho))
     assert_equal('large', Aozora2Html::Utils.create_font_size(1, :dai))
     assert_equal('x-small', Aozora2Html::Utils.create_font_size(2, :sho))
@@ -19,14 +19,14 @@ class UtilsTest < Test::Unit::TestCase
     assert_raise(Aozora2Html::Error) { Aozora2Html::Utils.create_font_size(0, :sho) }
   end
 
-  def test_create_midashi_tag()
+  def test_create_midashi_tag
     assert_equal('h5', Aozora2Html::Utils.create_midashi_tag('小'.to_sjis))
     assert_equal('h4', Aozora2Html::Utils.create_midashi_tag('中'.to_sjis))
     assert_equal('h3', Aozora2Html::Utils.create_midashi_tag('大'.to_sjis))
     assert_raise(Aozora2Html::Error) { Aozora2Html::Utils.create_midashi_tag('標準'.to_sjis) }
   end
 
-  def test_convert_japanese_number()
+  def test_convert_japanese_number
     assert_equal('1', Aozora2Html::Utils.convert_japanese_number('１'.to_sjis))
     assert_equal('2', Aozora2Html::Utils.convert_japanese_number('２'.to_sjis))
     assert_equal('8', Aozora2Html::Utils.convert_japanese_number('８'.to_sjis))


### PR DESCRIPTION
UTF-8対応のため、不要な`to_sjis`を削除します。
また、`lib/aozora2html.rb`とテスト以外では極力`to_sjis`を使わないようにします。