### PR TITLE
remove exit in `lib/aozora2html`; use exit in `bin/aozora2html`

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -77,6 +77,9 @@ Layout/LineLength:
 Lint/EmptyClass:
   AllowComments: true
 
+Lint/InheritException:
+  Enabled: false
+
 Metrics/AbcSize:
   Enabled: true
   Max: 260.05

--- a/bin/aozora2html
+++ b/bin/aozora2html
@@ -72,4 +72,6 @@ Dir.mktmpdir do |dir|
     output = File.read(dest_file)
     print output
   end
+rescue Aozora2Html::FatalError
+  exit(2)
 end

--- a/lib/aozora2html.rb
+++ b/lib/aozora2html.rb
@@ -194,7 +194,7 @@ class Aozora2Html
     rescue Aozora2Html::Error => e
       puts e.message(line_number)
       if e.is_a?(Aozora2Html::Error)
-        exit(2)
+        raise Aozora2Html::FatalError
       end
     end
     tail_output # final call

--- a/lib/aozora2html/error.rb
+++ b/lib/aozora2html/error.rb
@@ -14,4 +14,8 @@ class Aozora2Html
       I18n.t(:error_stop, line, @message)
     end
   end
+
+  # Aozora2Htmlクラス内でexitする代わりに例外をあげるためのfatal error用クラス
+  class FatalError < Exception
+  end
 end

--- a/lib/jstream.rb
+++ b/lib/jstream.rb
@@ -30,7 +30,7 @@ class Jstream
     rescue Aozora2Html::Error => e
       puts e.message(1)
       if e.is_a?(Aozora2Html::Error)
-        exit(2)
+        raise Aozora2Html::FatalError
       end
     ensure
       @file.rewind

--- a/lib/jstream.rb
+++ b/lib/jstream.rb
@@ -16,9 +16,7 @@ class Jstream
   CRLF = CR + LF
 
   # 初期化と同時に、いったん最初の行をscanして、改行コードがCR+LFかどうか調べる。
-  # CR+LFでない場合はエラーメッセージを出力してexitする(!)
-  #
-  # TODO: 将来的にはさすがにexitまではしないよう、仕様を変更する?
+  # CR+LFでない場合はエラーメッセージを出力して、例外Aozora2Html::FatalErrorを上げる
   def initialize(file_io)
     @line = 0
     @current_char = nil

--- a/test/test_jstream.rb
+++ b/test/test_jstream.rb
@@ -12,7 +12,7 @@ class JstreamTest < Test::Unit::TestCase
     orig_stdout = $stdout
     out = StringIO.new
     $stdout = out
-    assert_raises(SystemExit) do
+    assert_raises(Aozora2Html::FatalError) do
       Jstream.new(strio)
     end
     $stdout = orig_stdout


### PR DESCRIPTION
ライブラリとして使う場合にいきなりexit()しないようにするため、致命的なエラー用のクラス `Aozora2Html::FatalError`を追加し、exit()をこれに置き換えるようにします。