### PR TITLE
Remove class attributes of use_jisx0213 and use_unicode

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -20,6 +20,9 @@ Style/Documentation:
   Exclude:
     - 'test/**/*'
 
+Style/DoubleNegation:
+  Enabled: false
+
 Style/EmptyMethod:
   EnforcedStyle: expanded
   Enabled: true

--- a/bin/aozora2html
+++ b/bin/aozora2html
@@ -19,14 +19,8 @@ gaiji_dir = options['gaiji-dir'] || nil
 
 css_files = options['css-files']&.split(',')
 
-if options['use-jisx0213']
-  Aozora2Html::Tag::EmbedGaiji.use_jisx0213 = true
-  Aozora2Html::Tag::Accent.use_jisx0213 = true
-end
-
-if options['use-unicode']
-  Aozora2Html::Tag::EmbedGaiji.use_unicode = true
-end
+use_jisx0213 = !!options['use-jisx0213']
+use_unicode = !!options['use-unicode']
 
 if options['error-utf8']
   Aozora2Html::I18n.use_utf8 = true
@@ -64,9 +58,23 @@ Dir.mktmpdir do |dir|
     require 'aozora2html/zip'
     tmpfile = File.join(dir, 'aozora.txt')
     Aozora2Html::Zip.unzip(src_file, tmpfile)
-    Aozora2Html.new(tmpfile, dest_file, gaiji_dir: gaiji_dir, css_files: css_files).process
+    Aozora2Html.new(
+      tmpfile,
+      dest_file,
+      gaiji_dir: gaiji_dir,
+      css_files: css_files,
+      use_jisx0213: use_jisx0213,
+      use_unicode: use_unicode,
+    ).process
   else
-    Aozora2Html.new(src_file, dest_file, gaiji_dir: gaiji_dir, css_files: css_files).process
+    Aozora2Html.new(
+      src_file,
+      dest_file,
+      gaiji_dir: gaiji_dir,
+      css_files: css_files,
+      use_jisx0213: use_jisx0213,
+      use_unicode: use_unicode,
+    ).process
   end
   unless ARGV[1]
     output = File.read(dest_file)

--- a/bin/aozora2html
+++ b/bin/aozora2html
@@ -64,7 +64,7 @@ Dir.mktmpdir do |dir|
       gaiji_dir: gaiji_dir,
       css_files: css_files,
       use_jisx0213: use_jisx0213,
-      use_unicode: use_unicode,
+      use_unicode: use_unicode
     ).process
   else
     Aozora2Html.new(
@@ -73,7 +73,7 @@ Dir.mktmpdir do |dir|
       gaiji_dir: gaiji_dir,
       css_files: css_files,
       use_jisx0213: use_jisx0213,
-      use_unicode: use_unicode,
+      use_unicode: use_unicode
     ).process
   end
   unless ARGV[1]

--- a/lib/aozora2html.rb
+++ b/lib/aozora2html.rb
@@ -150,7 +150,7 @@ class Aozora2Html
     '5' => 'ヲ゛'.to_sjis
   }.freeze
 
-  def initialize(input, output, gaiji_dir: nil, css_files: nil)
+  def initialize(input, output, gaiji_dir: nil, css_files: nil, use_jisx0213: nil, use_unicode: nil)
     @stream = if input.respond_to?(:read) ## readable IO?
                 Jstream.new(input)
               else
@@ -163,6 +163,9 @@ class Aozora2Html
            end
     @gaiji_dir = gaiji_dir || '../../../gaiji/'
     @css_files = css_files || ['../../aozora.css']
+
+    @use_jisx0213 = use_jisx0213
+    @use_unicode = use_unicode
 
     @buffer = TextBuffer.new
     @ruby_buf = RubyBuffer.new
@@ -221,7 +224,7 @@ class Aozora2Html
       codes = matched[0].split('-')
       folder = sprintf('%1d-%02d', codes[0], codes[1])
       code = sprintf('%1d-%02d-%02d', *codes)
-      Aozora2Html::Tag::EmbedGaiji.new(self, folder, code, desc.gsub!(IGETA_MARK, ''), gaiji_dir: @gaiji_dir)
+      Aozora2Html::Tag::EmbedGaiji.new(self, folder, code, desc.gsub!(IGETA_MARK, ''), gaiji_dir: @gaiji_dir, use_jisx0213: @use_jisx0213, use_unicode: @use_unicode)
     else
       substring
     end
@@ -257,7 +260,7 @@ class Aozora2Html
   end
 
   def read_accent
-    Aozora2Html::AccentParser.new(@stream, ACCENT_END, @chuuki_table, @images, gaiji_dir: @gaiji_dir).process
+    Aozora2Html::AccentParser.new(@stream, ACCENT_END, @chuuki_table, @images, gaiji_dir: @gaiji_dir, use_jisx0213: @use_jisx0213).process
   end
 
   def read_to_nest(endchar)
@@ -654,9 +657,9 @@ class Aozora2Html
     end
 
     matched = command.match(/U\+([0-9A-F]{4,5})/)
-    if matched && Aozora2Html::Tag::EmbedGaiji.use_unicode
+    if matched && (Aozora2Html::Tag::EmbedGaiji.use_unicode || @use_unicode)
       unicode_num = matched[1]
-      Aozora2Html::Tag::EmbedGaiji.new(self, nil, nil, command, unicode_num, gaiji_dir: @gaiji_dir)
+      Aozora2Html::Tag::EmbedGaiji.new(self, nil, nil, command, unicode_num, gaiji_dir: @gaiji_dir, use_jisx0213: @use_jisx0213, use_unicode: @use_unicode)
     else
       # Unemb
       escape_gaiji(command)
@@ -1305,10 +1308,10 @@ class Aozora2Html
     elsif @chuuki_table[:dakutenkunoji]
       @out.printf("\t<li>「濁点付きくの字点」は「%s」で表しました。</li>\r\n".to_sjis, KU + DAKUTEN + NOJI)
     end
-    if @chuuki_table[:newjis] && !Aozora2Html::Tag::EmbedGaiji.use_jisx0213
+    if @chuuki_table[:newjis] && !(Aozora2Html::Tag::EmbedGaiji.use_jisx0213 || @use_jisx0213)
       @out.print "\t<li>「くの字点」をのぞくJIS X 0213にある文字は、画像化して埋め込みました。</li>\r\n".to_sjis
     end
-    if @chuuki_table[:accent] && !Aozora2Html::Tag::Accent.use_jisx0213
+    if @chuuki_table[:accent] && !(Aozora2Html::Tag::Accent.use_jisx0213 || @use_jisx0213)
       @out.print "\t<li>アクセント符号付きラテン文字は、画像化して埋め込みました。</li>\r\n".to_sjis
     end
     if @images[0]

--- a/lib/aozora2html.rb
+++ b/lib/aozora2html.rb
@@ -264,7 +264,7 @@ class Aozora2Html
   end
 
   def read_to_nest(endchar)
-    Aozora2Html::TagParser.new(@stream, endchar, @chuuki_table, @images, gaiji_dir: @gaiji_dir).process
+    Aozora2Html::TagParser.new(@stream, endchar, @chuuki_table, @images, gaiji_dir: @gaiji_dir, use_jisx0213: @use_jisx0213, use_unicode: @use_unicode).process
   end
 
   def finalize

--- a/lib/aozora2html/accent_parser.rb
+++ b/lib/aozora2html/accent_parser.rb
@@ -5,7 +5,7 @@ require_relative 'ruby_buffer'
 class Aozora2Html
   # accent特殊文字を生かすための再帰呼び出し
   class AccentParser < Aozora2Html
-    def initialize(input, endchar, chuuki, image, gaiji_dir:) # rubocop:disable Lint/MissingSuper
+    def initialize(input, endchar, chuuki, image, gaiji_dir:, use_jisx0213: nil) # rubocop:disable Lint/MissingSuper
       unless input.is_a?(Jstream)
         raise ArgumentError, 'tag_parser must supply Jstream as input'
       end
@@ -19,6 +19,7 @@ class Aozora2Html
       @endchar = endchar # 改行は越えられない <br />を出力していられない
       @closed = nil # 改行での強制撤退チェックフラグ
       @encount_accent = nil
+      @use_jisx0213 = use_jisx0213
     end
 
     # 出力は配列で返す
@@ -46,14 +47,14 @@ class Aozora2Html
             if found2.is_a?(Hash)
               found3 = found2[@stream.peek_char(1)]
               if found3
-                first = Aozora2Html::Tag::Accent.new(self, *found3, gaiji_dir: @gaiji_dir)
+                first = Aozora2Html::Tag::Accent.new(self, *found3, gaiji_dir: @gaiji_dir, use_jisx0213: @use_jisx0213)
                 @encount_accent = true
                 @chuuki_table[:accent] = true
                 read_char
                 read_char
               end
             elsif found2
-              first = Aozora2Html::Tag::Accent.new(self, *found2, gaiji_dir: @gaiji_dir)
+              first = Aozora2Html::Tag::Accent.new(self, *found2, gaiji_dir: @gaiji_dir, use_jisx0213: @use_jisx0213)
               @encount_accent = true
               read_char
               @chuuki_table[:accent] = true

--- a/lib/aozora2html/tag/accent.rb
+++ b/lib/aozora2html/tag/accent.rb
@@ -10,10 +10,11 @@ class Aozora2Html
         attr_accessor :use_jisx0213
       end
 
-      def initialize(parser, code, name, gaiji_dir:)
+      def initialize(parser, code, name, gaiji_dir:, use_jisx0213: nil)
         @code = code
         @name = name
         @gaiji_dir = gaiji_dir
+        @use_jisx0213 = use_jisx0213
         super
       end
 
@@ -26,7 +27,7 @@ class Aozora2Html
       end
 
       def to_s
-        if Aozora2Html::Tag::Accent.use_jisx0213
+        if Aozora2Html::Tag::Accent.use_jisx0213 || @use_jisx0213
           jisx0213_to_unicode(@code.sub(%r{.*/}, '').to_sym)
         else
           "<img src=\"#{@gaiji_dir}#{@code}.png\" alt=\"" + GAIJI_MARK + "(#{@name})\" class=\"gaiji\" />"

--- a/lib/aozora2html/tag/embed_gaiji.rb
+++ b/lib/aozora2html/tag/embed_gaiji.rb
@@ -25,12 +25,14 @@ class Aozora2Html
         attr_reader :use_unicode
       end
 
-      def initialize(parser, folder, code, name, unicode_num = nil, gaiji_dir:)
+      def initialize(parser, folder, code, name, unicode_num = nil, gaiji_dir:, use_jisx0213: nil, use_unicode: nil)
         @folder = folder
         @code = code
         @name = name
         @unicode = unicode_num
         @gaiji_dir = gaiji_dir
+        @use_jisx0213 = use_jisx0213
+        @use_unicode = use_unicode
         super
       end
 
@@ -39,9 +41,9 @@ class Aozora2Html
       end
 
       def to_s
-        if Aozora2Html::Tag::EmbedGaiji.use_jisx0213 && @code
+        if (Aozora2Html::Tag::EmbedGaiji.use_jisx0213 || @use_jisx0213) && @code
           jisx0213_to_unicode(@code.to_sym)
-        elsif Aozora2Html::Tag::EmbedGaiji.use_unicode && @unicode
+        elsif (Aozora2Html::Tag::EmbedGaiji.use_unicode || @use_unicode) && @unicode
           "&#x#{@unicode};"
         else
           "<img src=\"#{@gaiji_dir}#{@folder}/#{@code}.png\" alt=\"" + GAIJI_MARK + "(#{@name})\" class=\"gaiji\" />"

--- a/lib/aozora2html/tag_parser.rb
+++ b/lib/aozora2html/tag_parser.rb
@@ -7,13 +7,15 @@ class Aozora2Html
   #
   # 青空記法の入れ子に対応（？）
   class TagParser < Aozora2Html
-    def initialize(input, endchar, chuuki, image, gaiji_dir:) # rubocop:disable Lint/MissingSuper
+    def initialize(input, endchar, chuuki, image, gaiji_dir:, use_jisx0213: nil, use_unicode: nil) # rubocop:disable Lint/MissingSuper
       unless input.is_a?(Jstream)
         raise ArgumentError, 'tag_parser must supply Jstream as input'
       end
 
       @stream = input
       @gaiji_dir = gaiji_dir
+      @use_jisx0213 = use_jisx0213
+      @use_unicode = use_unicode
       @buffer = TextBuffer.new
       @ruby_buf = RubyBuffer.new
       @chuuki_table = chuuki

--- a/test/test_aozora_accent_parser.rb
+++ b/test/test_aozora_accent_parser.rb
@@ -32,12 +32,21 @@ class Aozora2HtmlAccentParserTest < Test::Unit::TestCase
     end
   end
 
-  def test_use_jisx0213
+  def test_use_jisx0213_class
     Aozora2Html::Tag::Accent.use_jisx0213 = true
     str = "〔e'tiquette〕\r\n".to_sjis
     strio = StringIO.new(str)
     stream = Jstream.new(strio)
     parsed = Aozora2Html::AccentParser.new(stream, '〕'.to_sjis, {}, [], gaiji_dir: 'g_dir/').process
+    expected = '〔&#x00E9;tiquette'
+    assert_equal expected, parsed.to_s.to_utf8
+  end
+
+  def test_use_jisx0213
+    str = "〔e'tiquette〕\r\n".to_sjis
+    strio = StringIO.new(str)
+    stream = Jstream.new(strio)
+    parsed = Aozora2Html::AccentParser.new(stream, '〕'.to_sjis, {}, [], gaiji_dir: 'g_dir/', use_jisx0213: true).process
     expected = '〔&#x00E9;tiquette'
     assert_equal expected, parsed.to_s.to_utf8
   end

--- a/test/test_command_parse.rb
+++ b/test/test_command_parse.rb
@@ -98,7 +98,7 @@ class CommandParseTest < Test::Unit::TestCase
     assert_equal expected, parsed
   end
 
-  def test_parse_command_unicode
+  def test_parse_command_unicode_class
     Aozora2Html::Tag::EmbedGaiji.use_unicode = true
     src = "※［＃「衄のへん＋卩」、U+5379、287-2］\r\n"
     parsed = parse_text(src)
@@ -106,7 +106,14 @@ class CommandParseTest < Test::Unit::TestCase
     assert_equal expected, parsed
   end
 
-  def test_parse_command_teisei1
+  def test_parse_command_unicode
+    src = "※［＃「衄のへん＋卩」、U+5379、287-2］\r\n"
+    parsed = parse_text(src, use_unicode: true)
+    expected = "&#x5379;<br />\r\n"
+    assert_equal expected, parsed
+  end
+
+  def test_parse_command_teisei1_class
     Aozora2Html::Tag::EmbedGaiji.use_unicode = true
     src = "吹喋［＃「喋」に「ママ」の注記］\r\n"
     parsed = parse_text(src)
@@ -114,7 +121,14 @@ class CommandParseTest < Test::Unit::TestCase
     assert_equal expected, parsed
   end
 
-  def test_parse_command_teisei2
+  def test_parse_command_teisei1
+    src = "吹喋［＃「喋」に「ママ」の注記］\r\n"
+    parsed = parse_text(src, use_unicode: true)
+    expected = "吹<ruby><rb>喋</rb><rp>（</rp><rt>ママ</rt><rp>）</rp></ruby><br />\r\n"
+    assert_equal expected, parsed
+  end
+
+  def test_parse_command_teisei2_class
     Aozora2Html::Tag::EmbedGaiji.use_unicode = true
     src = "紋附だとか［＃「紋附だとか」は底本では「絞附だとか」］\r\n"
     parsed = parse_text(src)
@@ -122,7 +136,14 @@ class CommandParseTest < Test::Unit::TestCase
     assert_equal expected, parsed
   end
 
-  def test_parse_command_teisei3
+  def test_parse_command_teisei2
+    src = "紋附だとか［＃「紋附だとか」は底本では「絞附だとか」］\r\n"
+    parsed = parse_text(src, use_unicode: true)
+    expected = %Q(紋附だとか<span class="notes">［＃「紋附だとか」は底本では「絞附だとか」］</span><br />\r\n)
+    assert_equal expected, parsed
+  end
+
+  def test_parse_command_teisei3_class
     Aozora2Html::Tag::EmbedGaiji.use_unicode = true
     src = "私は籠《ざる》［＃ルビの「ざる」は底本では「さる」］をさげ\r\n"
     parsed = parse_text(src)
@@ -130,7 +151,14 @@ class CommandParseTest < Test::Unit::TestCase
     assert_equal expected, parsed
   end
 
-  def test_parse_command_teisei4
+  def test_parse_command_teisei3
+    src = "私は籠《ざる》［＃ルビの「ざる」は底本では「さる」］をさげ\r\n"
+    parsed = parse_text(src, use_unicode: true)
+    expected = %Q(私は<ruby><rb>籠</rb><rp>（</rp><rt>ざる</rt><rp>）</rp></ruby><span class="notes">［＃ルビの「ざる」は底本では「さる」］</span>をさげ<br />\r\n)
+    assert_equal expected, parsed
+  end
+
+  def test_parse_command_teisei4_class
     Aozora2Html::Tag::EmbedGaiji.use_unicode = true
     src = "広場へに［＃「広場へに」はママ］店でもだそう。\r\n"
     parsed = parse_text(src)
@@ -138,7 +166,14 @@ class CommandParseTest < Test::Unit::TestCase
     assert_equal expected, parsed
   end
 
-  def test_parse_command_teisei5
+  def test_parse_command_teisei4
+    src = "広場へに［＃「広場へに」はママ］店でもだそう。\r\n"
+    parsed = parse_text(src, use_unicode: true)
+    expected = %Q(広場へに<span class="notes">［＃「広場へに」はママ］</span>店でもだそう。<br />\r\n)
+    assert_equal expected, parsed
+  end
+
+  def test_parse_command_teisei5_class
     Aozora2Html::Tag::EmbedGaiji.use_unicode = true
     src = "お湯《ゆう》［＃ルビの「ゆう」はママ］\r\n"
     parsed = parse_text(src)
@@ -146,7 +181,14 @@ class CommandParseTest < Test::Unit::TestCase
     assert_equal expected, parsed
   end
 
-  def test_parse_command_tcy
+  def test_parse_command_teisei5
+    src = "お湯《ゆう》［＃ルビの「ゆう」はママ］\r\n"
+    parsed = parse_text(src, use_unicode: true)
+    expected = %Q(お<ruby><rb>湯</rb><rp>（</rp><rt>ゆう</rt><rp>）</rp></ruby><span class="notes">［＃ルビの「ゆう」はママ］</span><br />\r\n)
+    assert_equal expected, parsed
+  end
+
+  def test_parse_command_tcy_class
     Aozora2Html::Tag::EmbedGaiji.use_unicode = true
     src = "米機Ｂ29［＃「29」は縦中横］の編隊は、\r\n"
     parsed = parse_text(src)
@@ -154,7 +196,14 @@ class CommandParseTest < Test::Unit::TestCase
     assert_equal expected, parsed
   end
 
-  def test_parse_command_tcy2
+  def test_parse_command_tcy
+    src = "米機Ｂ29［＃「29」は縦中横］の編隊は、\r\n"
+    parsed = parse_text(src, use_unicode: true)
+    expected = %Q(米機Ｂ<span dir="ltr">29</span>の編隊は、<br />\r\n)
+    assert_equal expected, parsed
+  end
+
+  def test_parse_command_tcy2_class
     Aozora2Html::Tag::EmbedGaiji.use_unicode = true
     src = "［＃縦中横］（※［＃ローマ数字1、1-13-21］）［＃縦中横終わり］\r\n"
     parsed = parse_text(src)
@@ -162,7 +211,14 @@ class CommandParseTest < Test::Unit::TestCase
     assert_equal expected, parsed
   end
 
-  def test_parse_command_kogaki
+  def test_parse_command_tcy2
+    src = "［＃縦中横］（※［＃ローマ数字1、1-13-21］）［＃縦中横終わり］\r\n"
+    parsed = parse_text(src, use_unicode: true)
+    expected = %Q|<span dir="ltr">（<img src="../../../gaiji/1-13/1-13-21.png" alt="※(ローマ数字1、1-13-21)" class="gaiji" />）</span><br />\r\n|
+    assert_equal expected, parsed
+  end
+
+  def test_parse_command_kogaki_class
     Aozora2Html::Tag::EmbedGaiji.use_unicode = true
     src = "それ以上である。（５）［＃「（５）」は行右小書き］\r\n"
     parsed = parse_text(src)
@@ -170,7 +226,14 @@ class CommandParseTest < Test::Unit::TestCase
     assert_equal expected, parsed
   end
 
-  def test_parse_command_uetsuki
+  def test_parse_command_kogaki
+    src = "それ以上である。（５）［＃「（５）」は行右小書き］\r\n"
+    parsed = parse_text(src, use_unicode: true)
+    expected = %Q(それ以上である。<sup class="superscript">（５）</sup><br />\r\n)
+    assert_equal expected, parsed
+  end
+
+  def test_parse_command_uetsuki_class
     Aozora2Html::Tag::EmbedGaiji.use_unicode = true
     src = "22［＃「2」は上付き小文字］\r\n"
     parsed = parse_text(src)
@@ -178,7 +241,14 @@ class CommandParseTest < Test::Unit::TestCase
     assert_equal expected, parsed
   end
 
-  def test_parse_command_bouki
+  def test_parse_command_uetsuki
+    src = "22［＃「2」は上付き小文字］\r\n"
+    parsed = parse_text(src, use_unicode: true)
+    expected = %Q(2<sup class="superscript">2</sup><br />\r\n)
+    assert_equal expected, parsed
+  end
+
+  def test_parse_command_bouki_class
     Aozora2Html::Tag::EmbedGaiji.use_unicode = true
     src = "支部長の顔にさっと血が流れ［＃「血が流れ」に「×」の傍記］た\r\n"
     parsed = parse_text(src)
@@ -186,7 +256,14 @@ class CommandParseTest < Test::Unit::TestCase
     assert_equal expected, parsed
   end
 
-  def test_parse_command_ruby
+  def test_parse_command_bouki
+    src = "支部長の顔にさっと血が流れ［＃「血が流れ」に「×」の傍記］た\r\n"
+    parsed = parse_text(src, use_unicode: true)
+    expected = %Q(支部長の顔にさっと<ruby><rb>血が流れ</rb><rp>（</rp><rt>×&nbsp;×&nbsp;×&nbsp;×</rt><rp>）</rp></ruby>た<br />\r\n)
+    assert_equal expected, parsed
+  end
+
+  def test_parse_command_ruby_class
     Aozora2Html::Tag::EmbedGaiji.use_unicode = true
     src = "グリーンランドの中央部八千尺の氷河地帯にあるといわれる、［＃横組み］“Ser-mik-Suah《セルミク・シュアー》”［＃横組み終わり］の冥路《よみじ》の国。\r\n"
     parsed = parse_text(src)
@@ -194,12 +271,19 @@ class CommandParseTest < Test::Unit::TestCase
     assert_equal expected, parsed
   end
 
+  def test_parse_command_ruby
+    src = "グリーンランドの中央部八千尺の氷河地帯にあるといわれる、［＃横組み］“Ser-mik-Suah《セルミク・シュアー》”［＃横組み終わり］の冥路《よみじ》の国。\r\n"
+    parsed = parse_text(src, use_unicode: true)
+    expected = %Q(グリーンランドの中央部八千尺の氷河地帯にあるといわれる、<span class="yokogumi">“<ruby><rb>Ser-mik-Suah</rb><rp>（</rp><rt>セルミク・シュアー</rt><rp>）</rp></ruby>”</span>の<ruby><rb>冥路</rb><rp>（</rp><rt>よみじ</rt><rp>）</rp></ruby>の国。<br />\r\n)
+    assert_equal expected, parsed
+  end
+
   using Aozora2Html::StringRefinements
 
-  def parse_text(input_text)
+  def parse_text(input_text, use_jisx0213: nil, use_unicode: nil)
     input = StringIO.new(input_text.to_sjis)
     output = StringIO.new
-    parser = Aozora2Html.new(input, output)
+    parser = Aozora2Html.new(input, output, use_jisx0213: use_jisx0213, use_unicode: use_unicode)
     parser.instance_eval { @section = :tail }
     catch(:terminate) do
       loop do

--- a/test/test_gaiji_tag.rb
+++ b/test/test_gaiji_tag.rb
@@ -31,15 +31,25 @@ class EmbedGaijiTagTest < Test::Unit::TestCase
     assert_equal true, egt.escaped?
   end
 
-  def test_jisx0213
+  def test_jisx0213_class
     Aozora2Html::Tag::EmbedGaiji.use_jisx0213 = true
     egt = Aozora2Html::Tag::EmbedGaiji.new(nil, 'foo', '1-06-75', 'snowman', gaiji_dir: @gaiji_dir)
     assert_equal '&#x2603;', egt.to_s.to_utf8
   end
 
-  def test_use_unicode
+  def test_jisx0213
+    egt = Aozora2Html::Tag::EmbedGaiji.new(nil, 'foo', '1-06-75', 'snowman', gaiji_dir: @gaiji_dir, use_jisx0213: true)
+    assert_equal '&#x2603;', egt.to_s.to_utf8
+  end
+
+  def test_use_unicode_class
     Aozora2Html::Tag::EmbedGaiji.use_unicode = true
     egt = Aozora2Html::Tag::EmbedGaiji.new(nil, 'foo', '1-06-75', 'snowman', '2603', gaiji_dir: @gaiji_dir)
+    assert_equal '&#x2603;', egt.to_s.to_utf8
+  end
+
+  def test_use_unicode
+    egt = Aozora2Html::Tag::EmbedGaiji.new(nil, 'foo', '1-06-75', 'snowman', '2603', gaiji_dir: @gaiji_dir, use_unicode: true)
     assert_equal '&#x2603;', egt.to_s.to_utf8
   end
 

--- a/test/test_tag_parser.rb
+++ b/test/test_tag_parser.rb
@@ -66,12 +66,21 @@ class TagParserTest < Test::Unit::TestCase
     assert_equal expected, command.to_s.to_utf8
   end
 
-  def test_parse_gaiji_jisx0213
+  def test_parse_gaiji_jisx0213_class
     Aozora2Html::Tag::EmbedGaiji.use_jisx0213 = true
     str = "※［＃「てへん＋劣」、第3水準1-84-77］…\r\n".to_sjis
     strio = StringIO.new(str)
     stream = Jstream.new(strio)
     command, _raw = Aozora2Html::TagParser.new(stream, '…'.to_sjis, {}, [], gaiji_dir: 'g_dir/').process
+    expected = '&#x6318;'
+    assert_equal expected, command.to_s.to_utf8
+  end
+
+  def test_parse_gaiji_jisx0213
+    str = "※［＃「てへん＋劣」、第3水準1-84-77］…\r\n".to_sjis
+    strio = StringIO.new(str)
+    stream = Jstream.new(strio)
+    command, _raw = Aozora2Html::TagParser.new(stream, '…'.to_sjis, {}, [], gaiji_dir: 'g_dir/', use_jisx0213: true).process
     expected = '&#x6318;'
     assert_equal expected, command.to_s.to_utf8
   end


### PR DESCRIPTION
グローバルに影響するのを避けるため、`use_jisx0213` と `use_unicode` をクラスのインスタンス変数ではなくオブジェクトのインスタンス変数にします。